### PR TITLE
jwt 기반 spring security 인증, 인가와 계정 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 
     //jwt setting
     implementation 'com.auth0:java-jwt:4.3.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swef/cookcode/common/config/JwtConfig.java
+++ b/src/main/java/com/swef/cookcode/common/config/JwtConfig.java
@@ -1,0 +1,67 @@
+package com.swef.cookcode.common.config;
+
+import com.swef.cookcode.common.jwt.Jwt;
+import com.swef.cookcode.common.jwt.JwtAuthenticationFilter;
+import com.swef.cookcode.common.jwt.JwtAuthenticationProvider;
+import com.swef.cookcode.common.jwt.JwtService;
+import com.swef.cookcode.user.service.UserService;
+import com.swef.cookcode.user.service.UserSimpleService;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.jwt")
+@Getter
+@Setter
+public class JwtConfig {
+  private String issuer;
+  private String clientSecret;
+  private Token accessToken;
+  private Token refreshToken;
+  private String blackListPrefix;
+  @Getter
+  @Setter
+  public static class Token {
+    private String header;
+    private int expirySeconds;
+
+    @Override
+    public String toString() {
+      return "header: "+header+" expirySeconds: "+expirySeconds;
+    }
+  }
+
+  @Bean
+  @Qualifier("accessJwt")
+  public Jwt accessJwt() {
+    return new Jwt(
+        this.issuer,
+        this.clientSecret,
+        this.accessToken.expirySeconds);
+  }
+
+  @Bean
+  @Qualifier("refreshJwt")
+  public Jwt refreshJwt() {
+    return new Jwt(
+        this.issuer,
+        this.clientSecret,
+        this.refreshToken.expirySeconds);
+  }
+
+  @Bean
+  public JwtAuthenticationProvider jwtAuthenticationProvider(JwtService jwtService,
+                                                             UserService userService) {
+    return new JwtAuthenticationProvider(jwtService, userService);
+  }
+
+  @Bean
+  public JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService,
+                                                         UserSimpleService userSimpleService) {
+    return new JwtAuthenticationFilter(this.accessToken.header, jwtService, userSimpleService);
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/config/RedisConfig.java
+++ b/src/main/java/com/swef/cookcode/common/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.swef.cookcode.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.data.redis")
+@Getter
+@Setter
+public class RedisConfig {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private String host;
+
+  private int port;
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(connectionFactory);
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+    return redisTemplate;
+  }
+
+}

--- a/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.ErrorResponse;
 import com.swef.cookcode.common.filter.ExceptionHandlerFilter;
+import com.swef.cookcode.common.jwt.JwtAuthenticationFilter;
 import java.io.PrintWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -68,6 +69,7 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(
             HttpSecurity http,
+            JwtAuthenticationFilter jwtAuthenticationFilter,
             AccessDeniedHandler accessDeniedHandler,
             AuthenticationEntryPoint authenticationEntryPoint
     ) throws Exception {
@@ -80,13 +82,15 @@ public class WebSecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeHttpRequests()
-                .anyRequest().permitAll()
+                .requestMatchers("/api/v1/account/signin", "/api/v1/account/signup").permitAll()
+                .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()
                 .accessDeniedHandler(accessDeniedHandler)
                 .authenticationEntryPoint(authenticationEntryPoint)
                 .and()
-                .addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/swef/cookcode/common/jwt/Jwt.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/Jwt.java
@@ -1,0 +1,54 @@
+package com.swef.cookcode.common.jwt;
+
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.swef.cookcode.common.jwt.claims.AccessClaim;
+import com.swef.cookcode.common.jwt.claims.Claims;
+import com.swef.cookcode.common.jwt.claims.RefreshClaim;
+import java.util.Date;
+import lombok.Getter;
+
+@Getter
+public class Jwt {
+  private final String issuer;
+
+  private final String clientSecret;
+
+  private final int expirySeconds;
+
+  private final Algorithm algorithm;
+
+  private final JWTVerifier jwtVerifier;
+
+  public Jwt(String issuer, String clientSecret, int expirySeconds) {
+    this.issuer = issuer;
+    this.clientSecret = clientSecret;
+    this.expirySeconds = expirySeconds;
+    this.algorithm = Algorithm.HMAC512(clientSecret);
+    this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
+        .withIssuer(issuer)
+        .build();
+  }
+
+  public String sign(Claims claims){
+    Date now = new Date();
+    JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
+    builder.withIssuer(issuer);
+    builder.withIssuedAt(now);
+    if(expirySeconds > 0) {
+      builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+    }
+    claims.applyToBuilder(builder);
+    return  builder.sign(algorithm);
+  }
+
+  public AccessClaim verifyAccessToken(String token) throws JWTVerificationException {
+    return new AccessClaim(jwtVerifier.verify(token));
+  }
+
+  public RefreshClaim verifyRefreshToken(String token) throws JWTVerificationException {
+    return new RefreshClaim(jwtVerifier.verify(token));
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,90 @@
+package com.swef.cookcode.common.jwt;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.springframework.util.StringUtils.hasText;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.swef.cookcode.common.error.exception.AuthErrorException;
+import com.swef.cookcode.common.jwt.claims.AccessClaim;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserSimpleService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final String accessHeaderKey;
+
+  private final JwtService jwtService;
+
+  private final UserSimpleService userSimpleService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                  FilterChain chain) throws ServletException, IOException {
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
+      String token = getAccessToken(request);
+      if (nonNull(token)) {
+        try {
+          AccessClaim claims = jwtService.verifyAccessToken(token);
+          Long userId = claims.getUserId();
+          List<GrantedAuthority> authorities = getAuthorities(claims);
+          User currentUser = userSimpleService.getUserById(userId);
+          if (!isNull(userId) && authorities.size() > 0) {
+            JwtAuthenticationToken authentication = new JwtAuthenticationToken(new JwtPrincipal(token, currentUser), null, authorities);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+          }
+        } catch (TokenExpiredException e) {
+          log.warn("토큰이 만료된 요청입니다. token: {}", token);
+          throw e;
+        } catch (AuthErrorException e) {
+          log.warn("로그아웃 처리된 토큰입니다. token: {}", token);
+          throw e;
+        } catch (Exception e) {
+          log.warn("Jwt 처리 실패: {}, class: {}", e.getMessage(), e.getClass());
+          throw e;
+        }
+      }
+    } else {
+      log.debug("SecurityContextHolder는 이미 authentication 객체를 가지고 있습니다.: '{}'", SecurityContextHolder.getContext().getAuthentication());
+    }
+    chain.doFilter(request, response);
+  }
+
+  private String getAccessToken(HttpServletRequest request) {
+    String token = request.getHeader(accessHeaderKey);
+    if(hasText(token)) {
+      log.debug("Jwt authorization api detected: {}", token);
+      return URLDecoder.decode(token, StandardCharsets.UTF_8);
+    }
+    return null;
+  }
+
+  private List<GrantedAuthority> getAuthorities(AccessClaim claims) {
+    String[] roles = claims.getRoles();
+    return roles == null || roles.length == 0 ? Collections.emptyList() : Arrays.stream(roles).map(
+        SimpleGrantedAuthority::new).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,54 @@
+package com.swef.cookcode.common.jwt;
+
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserService;
+import java.util.List;
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.util.Assert;
+
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+  private final JwtService jwtService;
+
+  private final UserService userService;
+
+  public JwtAuthenticationProvider(
+          JwtService jwtService, UserService userService) {
+    this.jwtService = jwtService;
+    this.userService = userService;
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+    return processUserAuthentication(String.valueOf(jwtAuthentication.getPrincipal()), jwtAuthentication.getCredentials());
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    Assert.isAssignable(authentication, JwtAuthenticationToken.class);
+    return true;
+  }
+
+  private Authentication processUserAuthentication(String principal, String credentials) {
+    try{
+      User user = userService.signIn(principal, credentials);
+      List<GrantedAuthority> authorities = List.of(user.getAuthority().toGrantedAuthority());
+      String accessToken = jwtService.createAccessToken(user.getId(), user.getEmail(), authorities);
+      String refreshToken = jwtService.createRefreshToken(user.getEmail());
+      JwtAuthenticationToken authenticated = new JwtAuthenticationToken(new JwtPrincipal(accessToken, user), null, authorities);
+      authenticated.setDetails(refreshToken);
+      return authenticated;
+    } catch (IllegalArgumentException e) {
+      throw new BadCredentialsException(e.getMessage());
+    } catch (DataAccessException e) {
+      throw new AuthenticationServiceException(e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,52 @@
+package com.swef.cookcode.common.jwt;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+  private final Object principal;
+
+  private String credentials;
+
+  public JwtAuthenticationToken(String principal, String credentials) {
+    super(null);
+    super.setAuthenticated(false);
+
+    this.principal = principal;
+    this.credentials = credentials;
+  }
+
+  JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    super.setAuthenticated(true);
+
+    this.principal = principal;
+    this.credentials = credentials;
+  }
+
+  @Override
+  public String getCredentials() {
+    return credentials;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return principal;
+  }
+
+  public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    if (isAuthenticated) {
+      throw new IllegalArgumentException("Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead.");
+    }
+    super.setAuthenticated(false);
+  }
+
+  @Override
+  public void eraseCredentials() {
+    super.eraseCredentials();
+    credentials = null;
+  }
+}
+

--- a/src/main/java/com/swef/cookcode/common/jwt/JwtPrincipal.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/JwtPrincipal.java
@@ -1,0 +1,32 @@
+package com.swef.cookcode.common.jwt;
+
+import static com.swef.cookcode.common.ErrorCode.EMAIL_REQUIRED;
+import static com.swef.cookcode.common.ErrorCode.USER_PARAM_REQUIRED;
+import static java.util.Objects.isNull;
+import static org.springframework.util.StringUtils.hasText;
+
+import com.swef.cookcode.common.error.exception.InvalidRequestException;
+import com.swef.cookcode.user.domain.User;
+import java.security.Principal;
+import lombok.Getter;
+
+@Getter
+public class JwtPrincipal implements Principal {
+
+  private final String accessToken;
+
+  private final User user;
+
+  public JwtPrincipal(String accessToken, User user) {
+    if(!hasText(accessToken)) throw new InvalidRequestException(EMAIL_REQUIRED);
+    if(isNull(user)) throw new InvalidRequestException(USER_PARAM_REQUIRED);
+
+    this.accessToken = accessToken;
+    this.user = user;
+  }
+
+  @Override
+  public String getName() {
+    return user.getId().toString();
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/JwtService.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/JwtService.java
@@ -1,0 +1,106 @@
+package com.swef.cookcode.common.jwt;
+
+import static com.swef.cookcode.common.ErrorCode.BLACKLIST_TOKEN_REQUEST;
+import static com.swef.cookcode.common.ErrorCode.INVALID_REFRESH_TOKEN_REQUEST;
+import static com.swef.cookcode.common.ErrorCode.REDIS_TOKEN_NOT_FOUND;
+import static com.swef.cookcode.common.ErrorCode.TOKEN_EXPIRED;
+import static com.swef.cookcode.common.ErrorCode.TOKEN_NOT_EXPIRED;
+import static com.swef.cookcode.common.ErrorCode.TOKEN_USER_ID_NOT_MATCHED;
+import static java.util.Objects.isNull;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.swef.cookcode.common.config.JwtConfig;
+import com.swef.cookcode.common.error.exception.AuthErrorException;
+import com.swef.cookcode.common.error.exception.InvalidRequestException;
+import com.swef.cookcode.common.jwt.claims.AccessClaim;
+import com.swef.cookcode.common.jwt.claims.RefreshClaim;
+import com.swef.cookcode.common.service.RedisService;
+import com.swef.cookcode.user.domain.User;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+  private final Jwt accessJwt;
+
+  private final Jwt refreshJwt;
+
+  private final JwtConfig jwtConfig;
+
+  private final RedisService redisService;
+
+  public JwtService(@Qualifier("accessJwt") Jwt accessJwt, @Qualifier("refreshJwt") Jwt refreshJwt, JwtConfig jwtConfig,
+                    RedisService redisService) {
+    this.accessJwt = accessJwt;
+    this.refreshJwt = refreshJwt;
+    this.jwtConfig = jwtConfig;
+    this.redisService = redisService;
+  }
+
+  public int getRefreshExpiry() {
+    return refreshJwt.getExpirySeconds();
+  }
+
+  public String createAccessToken(Long userId, String email, List<GrantedAuthority> authorities) {
+    String[] roles = authorities.stream()
+        .map(GrantedAuthority::getAuthority)
+        .toArray(String[]::new);
+    return accessJwt.sign(new AccessClaim(userId, email, roles));
+  }
+
+  public String createRefreshToken(String email) {
+    String refreshToken = refreshJwt.sign(new RefreshClaim(email));
+    redisService.setValues(email, refreshToken, Duration.ofSeconds(
+        refreshJwt.getExpirySeconds()));
+    return refreshToken;
+  }
+
+  public void checkRefreshToken(String email, String refreshToken) {
+    try{
+      refreshJwt.verifyRefreshToken(refreshToken);
+    } catch (TokenExpiredException e) {
+      throw new AuthErrorException(TOKEN_EXPIRED);
+    }
+    String redisToken = (String) redisService.getValues(email);
+    if(isNull(redisToken)) throw new AuthErrorException(REDIS_TOKEN_NOT_FOUND);
+    if(!redisToken.equals(refreshToken)) {
+      throw new AuthErrorException(INVALID_REFRESH_TOKEN_REQUEST);
+    }
+  }
+
+  public String reissueAccessToken(User user, String expiredAccessToken, String refreshToken) {
+    Date now = new Date();
+    try {
+      AccessClaim claims = verifyAccessToken(expiredAccessToken);
+      if (!claims.getUserId().equals(user.getId())) throw new InvalidRequestException(TOKEN_USER_ID_NOT_MATCHED);
+      if (claims.getExp().getTime() - now.getTime() >= 1000 * 60 * 5) {
+        throw new InvalidRequestException(TOKEN_NOT_EXPIRED);
+      } else {
+        throw new TokenExpiredException(TOKEN_EXPIRED.getMessage(), Instant.now());
+      }
+    } catch (TokenExpiredException e) {
+      checkRefreshToken(user.getEmail(), refreshToken);
+      List<GrantedAuthority> authorities = List.of(user.getAuthority().toGrantedAuthority());
+      return createAccessToken(user.getId(), user.getEmail(), authorities);
+    }
+  }
+
+  public void signOut(String token) {
+    AccessClaim claim = accessJwt.verifyAccessToken(token);
+    long expiredAccessTokenTime = claim.getExp().getTime() - new Date().getTime();
+    redisService.setValues(jwtConfig.getBlackListPrefix() + token, claim.getEmail(), Duration.ofMillis(expiredAccessTokenTime));
+    redisService.deleteValues(claim.getEmail());
+  }
+
+  public AccessClaim verifyAccessToken(String token) {
+    String expiredAt = (String) redisService.getValues(jwtConfig.getBlackListPrefix() + token);
+    if (expiredAt != null) throw new AuthErrorException(BLACKLIST_TOKEN_REQUEST);
+    return accessJwt.verifyAccessToken(token);
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/claims/AccessClaim.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/claims/AccessClaim.java
@@ -1,0 +1,46 @@
+package com.swef.cookcode.common.jwt.claims;
+
+import com.auth0.jwt.JWTCreator.Builder;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import lombok.Getter;
+
+@Getter
+public class AccessClaim implements Claims {
+  private Long userId;
+  private String email;
+  private String[] roles;
+  private Date iat; // 발행 시각
+  private Date exp; // 만료 시각
+
+  public AccessClaim(Long userId, String email, String[] roles){
+    this.userId = userId;
+    this.email = email;
+    this.roles = roles;
+  };
+
+  public AccessClaim(DecodedJWT decodedJWT) {
+    Claim userId = decodedJWT.getClaim("userId");
+    if (!userId.isNull()) {
+      this.userId = userId.asLong();
+    }
+    Claim email = decodedJWT.getClaim("email");
+    if (!email.isNull()) {
+      this.email = email.asString();
+    }
+    Claim roles = decodedJWT.getClaim("roles");
+    if (!roles.isNull()) {
+      this.roles = roles.asArray(String.class);
+    }
+    this.iat = decodedJWT.getIssuedAt();
+    this.exp = decodedJWT.getExpiresAt();
+  }
+
+  @Override
+  public void applyToBuilder(Builder builder) {
+    builder.withClaim("userId", this.userId);
+    builder.withClaim("email", this.email);
+    builder.withArrayClaim("roles", this.roles);
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/claims/Claims.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/claims/Claims.java
@@ -1,0 +1,6 @@
+package com.swef.cookcode.common.jwt.claims;
+
+import com.auth0.jwt.JWTCreator.Builder;
+public interface Claims {
+  void applyToBuilder(Builder builder);
+}

--- a/src/main/java/com/swef/cookcode/common/jwt/claims/RefreshClaim.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/claims/RefreshClaim.java
@@ -1,0 +1,33 @@
+package com.swef.cookcode.common.jwt.claims;
+
+import com.auth0.jwt.JWTCreator.Builder;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import lombok.Getter;
+
+@Getter
+public class RefreshClaim implements Claims {
+
+  private String email ;
+  private Date iat; // 발행 시각
+  private Date exp; // 만료 시각
+
+  public RefreshClaim(String email){
+    this.email = email;
+  };
+
+  public RefreshClaim(DecodedJWT decodedJWT) {
+    Claim email = decodedJWT.getClaim("email");
+    if (!email.isNull()) {
+      this.email = email.asString();
+    }
+    this.iat = decodedJWT.getIssuedAt();
+    this.exp = decodedJWT.getExpiresAt();
+  }
+
+  @Override
+  public void applyToBuilder(Builder builder) {
+    builder.withClaim("email", this.email);
+  }
+}

--- a/src/main/java/com/swef/cookcode/common/service/RedisService.java
+++ b/src/main/java/com/swef/cookcode/common/service/RedisService.java
@@ -1,0 +1,35 @@
+package com.swef.cookcode.common.service;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisService {
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public RedisService(
+      RedisTemplate<String, Object> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public void setValues(String key, String data) {
+    ValueOperations<String, Object> values = redisTemplate.opsForValue();
+    values.set(key, data);
+  }
+
+  public void setValues(String key, String data, Duration duration) {
+    ValueOperations<String, Object> values = redisTemplate.opsForValue();
+    values.set(key, data, duration);
+  }
+
+  public Object getValues(String key) {
+    ValueOperations<String, Object> values = redisTemplate.opsForValue();
+    return values.get(key);
+  }
+
+  public void deleteValues(String key) {
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.common.jwt.JwtAuthenticationToken;
 import com.swef.cookcode.common.jwt.JwtPrincipal;
 import com.swef.cookcode.user.domain.User;
@@ -11,13 +12,19 @@ import com.swef.cookcode.user.dto.request.UserSignInRequest;
 import com.swef.cookcode.user.dto.request.UserSignUpRequest;
 import com.swef.cookcode.user.dto.response.SignInResponse;
 import com.swef.cookcode.user.dto.response.SignUpResponse;
+import com.swef.cookcode.user.dto.response.UserDetailResponse;
 import com.swef.cookcode.user.service.UserService;
+import com.swef.cookcode.user.service.UserSimpleService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,9 +36,12 @@ import org.springframework.web.bind.annotation.RestController;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class AccountController {
 
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
     private final AuthenticationManager authenticationManager;
 
     private final UserService userService;
+
+    private final UserSimpleService userSimpleService;
 
     @PostMapping("/signin")
     public ResponseEntity<ApiResponse<SignInResponse>> signIn(
@@ -65,5 +75,18 @@ public class AccountController {
                 .data(SignUpResponse.from(newUser))
                 .build();
         return ResponseEntity.created(URI.create("/signup")).body(response);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> getUserInfo(@CurrentUser User user, @PathVariable("userId") Long userId) {
+        User returnedUser = userSimpleService.getUserById(userId);
+        UserDetailResponse res = UserDetailResponse.from(returnedUser);
+        log.info("user {} get info of user {}", user.getNickname(), returnedUser.getNickname());
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("유저 정보 조회 성공")
+                .status(CREATED.value())
+                .data(res)
+                .build();
+        return ResponseEntity.ok(apiResponse);
     }
 }

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -1,0 +1,69 @@
+package com.swef.cookcode.user.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.jwt.JwtAuthenticationToken;
+import com.swef.cookcode.common.jwt.JwtPrincipal;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.request.UserSignInRequest;
+import com.swef.cookcode.user.dto.request.UserSignUpRequest;
+import com.swef.cookcode.user.dto.response.SignInResponse;
+import com.swef.cookcode.user.dto.response.SignUpResponse;
+import com.swef.cookcode.user.service.UserService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/account")
+@RequiredArgsConstructor
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AccountController {
+
+    private final AuthenticationManager authenticationManager;
+
+    private final UserService userService;
+
+    @PostMapping("/signin")
+    public ResponseEntity<ApiResponse<SignInResponse>> signIn(
+            @RequestBody @Valid UserSignInRequest request) {
+
+        JwtAuthenticationToken authToken = new JwtAuthenticationToken(request.getEmail(),
+                request.getPassword());
+        Authentication authentication = authenticationManager.authenticate(authToken);
+        String refreshToken = (String) authentication.getDetails();
+        JwtPrincipal principal = (JwtPrincipal) authentication.getPrincipal();
+        ApiResponse response = ApiResponse.builder()
+                .message("로그인 성공하였습니다.")
+                .status(OK.value())
+                .data(SignInResponse.builder()
+                        .userId(principal.getUser().getId())
+                        .accessToken(principal.getAccessToken())
+                        .refreshToken(refreshToken)
+                        .build())
+                .build();
+        return ResponseEntity.ok()
+                .body(response);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignUpResponse>> signUp(@RequestBody @Valid
+                                                              UserSignUpRequest request) {
+        User newUser = userService.signUp(request);
+        ApiResponse response = ApiResponse.builder()
+                .message("회원가입 성공하였습니다.")
+                .status(CREATED.value())
+                .data(SignUpResponse.from(newUser))
+                .build();
+        return ResponseEntity.created(URI.create("/signup")).body(response);
+    }
+}

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -12,11 +12,14 @@ import com.swef.cookcode.user.dto.request.UserSignInRequest;
 import com.swef.cookcode.user.dto.request.UserSignUpRequest;
 import com.swef.cookcode.user.dto.response.SignInResponse;
 import com.swef.cookcode.user.dto.response.SignUpResponse;
+import com.swef.cookcode.user.dto.response.UniqueCheckResponse;
 import com.swef.cookcode.user.dto.response.UserDetailResponse;
 import com.swef.cookcode.user.service.UserService;
 import com.swef.cookcode.user.service.UserSimpleService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -75,6 +79,18 @@ public class AccountController {
                 .data(SignUpResponse.from(newUser))
                 .build();
         return ResponseEntity.created(URI.create("/signup")).body(response);
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<ApiResponse<UniqueCheckResponse>> checkNicknameValid(
+            @RequestParam(value = "nickname") String nickname) {
+        UniqueCheckResponse response = new UniqueCheckResponse(userSimpleService.checkNicknameUnique(nickname));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("중복 검사가 완료되었습니다.")
+                .status(OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok(apiResponse);
     }
 
     @GetMapping("/{userId}")

--- a/src/main/java/com/swef/cookcode/user/controller/UserController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/UserController.java
@@ -1,4 +1,0 @@
-package com.swef.cookcode.user.controller;
-
-public class UserController {
-}

--- a/src/main/java/com/swef/cookcode/user/domain/Status.java
+++ b/src/main/java/com/swef/cookcode/user/domain/Status.java
@@ -3,5 +3,5 @@ package com.swef.cookcode.user.domain;
 public enum Status {
     BLOCKED,
     VALID,
-    INF_REQUEST
+    INF_REQUESTED
 }

--- a/src/main/java/com/swef/cookcode/user/domain/User.java
+++ b/src/main/java/com/swef/cookcode/user/domain/User.java
@@ -1,6 +1,12 @@
 package com.swef.cookcode.user.domain;
 
+import static com.swef.cookcode.common.ErrorCode.INVALID_INPUT_VALUE;
+import static com.swef.cookcode.common.ErrorCode.INVALID_LENGTH;
+import static com.swef.cookcode.common.ErrorCode.MISSING_REQUEST_PARAMETER;
+import static org.springframework.util.StringUtils.hasText;
+
 import com.swef.cookcode.common.entity.BaseEntity;
+import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +15,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +28,7 @@ public class User extends BaseEntity {
 
     private static final String EMAIL_REGEX = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$";
 
-    private static final String NAME_REGEX = "[a-zA-Z가-힣]+( [a-zA-Z가-힣]+)*";
+    private static final String NICKNAME_REGEX = "^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$";
     private static final int MAX_EMAIL_LENGTH = 100;
     private static final int MAX_NICKNAME_LENGTH = 10;
     private static final int MAX_PROFILEIMAGE_LENGTH = 300;
@@ -47,4 +54,44 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Status status = Status.VALID;
+
+    public User(String email, String nickname, Authority authority) {
+        if (!hasText(email)) {
+            throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+        }
+        if (!hasText(nickname)) {
+            throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+        }
+
+        validateEmail(email);
+        validateNickName(nickname);
+
+        this.authority = authority;
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    public void updateAuthority(Authority authority) {
+        this.authority = authority;
+    }
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+    private static void validateNickName(String name) {
+        if (name.length() > MAX_NICKNAME_LENGTH) {
+            throw new InvalidRequestException(INVALID_LENGTH);
+        }
+        if (!Pattern.matches(NICKNAME_REGEX, name)) {
+            throw new InvalidRequestException(INVALID_INPUT_VALUE);
+        }
+    }
+
+    private static void validateEmail(String email) {
+        if (email.length() > MAX_EMAIL_LENGTH) {
+            throw new InvalidRequestException(INVALID_LENGTH);
+        }
+        if (!Pattern.matches(EMAIL_REGEX, email)) {
+            throw new InvalidRequestException(INVALID_INPUT_VALUE);
+        }
+    }
 }

--- a/src/main/java/com/swef/cookcode/user/dto/request/UserSignInRequest.java
+++ b/src/main/java/com/swef/cookcode/user/dto/request/UserSignInRequest.java
@@ -1,0 +1,16 @@
+package com.swef.cookcode.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignInRequest {
+  @NotBlank
+  private String email;
+  @NotBlank
+  private String password;
+}

--- a/src/main/java/com/swef/cookcode/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/swef/cookcode/user/dto/request/UserSignUpRequest.java
@@ -1,0 +1,22 @@
+package com.swef.cookcode.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserSignUpRequest {
+  @NotBlank
+  private String email;
+
+  @NotBlank
+  private String nickname;
+
+  @NotBlank
+  private String password;
+}

--- a/src/main/java/com/swef/cookcode/user/dto/response/SignInResponse.java
+++ b/src/main/java/com/swef/cookcode/user/dto/response/SignInResponse.java
@@ -1,0 +1,15 @@
+package com.swef.cookcode.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignInResponse {
+
+  private final Long userId;
+
+  private final String accessToken;
+
+  private final String refreshToken;
+}

--- a/src/main/java/com/swef/cookcode/user/dto/response/SignUpResponse.java
+++ b/src/main/java/com/swef/cookcode/user/dto/response/SignUpResponse.java
@@ -1,0 +1,24 @@
+package com.swef.cookcode.user.dto.response;
+
+import com.swef.cookcode.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignUpResponse {
+
+  private final Long userId;
+
+  private final String email;
+
+  private final String name;
+
+  public static SignUpResponse from(User user) {
+    return SignUpResponse.builder()
+        .userId(user.getId())
+        .email(user.getEmail())
+        .name(user.getNickname())
+        .build();
+  }
+}

--- a/src/main/java/com/swef/cookcode/user/dto/response/UniqueCheckResponse.java
+++ b/src/main/java/com/swef/cookcode/user/dto/response/UniqueCheckResponse.java
@@ -1,0 +1,13 @@
+package com.swef.cookcode.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UniqueCheckResponse {
+
+  private final Boolean isUnique;
+
+  public UniqueCheckResponse(Boolean isUnique) {
+    this.isUnique = isUnique;
+  }
+}

--- a/src/main/java/com/swef/cookcode/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/swef/cookcode/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,36 @@
+package com.swef.cookcode.user.dto.response;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import com.swef.cookcode.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserDetailResponse {
+    private final Long userId;
+
+    private final String email;
+
+    private final String nickname;
+
+    private final String profileImage;
+
+    private final String status;
+
+    private final String authority;
+
+    public static UserDetailResponse from(User user) {
+        return UserDetailResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileImage(hasText(user.getProfileImage()) ? user.getProfileImage() : null)
+                .status(user.getStatus().toString())
+                .authority(user.getAuthority().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -1,7 +1,15 @@
 package com.swef.cookcode.user.repository;
 
 import com.swef.cookcode.user.domain.User;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByIdAndIsQuit(@Param("userId") Long userId, @Param("isQuit") Boolean isQuit);
+
+    Optional<User> findByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
+
+    boolean existsByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
+
 }

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
 
+    boolean existsByNicknameAndIsQuit(@Param("nickname") String nickname, @Param("isQuit") Boolean isQuit);
+
 }

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -1,4 +1,58 @@
 package com.swef.cookcode.user.service;
 
+import static com.swef.cookcode.common.ErrorCode.LOGIN_PARAM_REQUIRED;
+import static com.swef.cookcode.common.ErrorCode.USER_ALREADY_EXISTS;
+import static com.swef.cookcode.common.ErrorCode.USER_NOT_FOUND;
+import static org.springframework.util.StringUtils.hasText;
+
+import com.swef.cookcode.common.error.exception.AlreadyExistsException;
+import com.swef.cookcode.common.error.exception.InvalidRequestException;
+import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.user.domain.Authority;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.request.UserSignUpRequest;
+import com.swef.cookcode.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User signIn(String principal, String credentials) {
+        if (!hasText(principal) || !hasText(credentials)) {
+            throw new InvalidRequestException(LOGIN_PARAM_REQUIRED);
+        }
+        User user = userRepository.findByEmailAndIsQuit(principal, false)
+                .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+        user.checkPassword(passwordEncoder, credentials);
+        return user;
+    }
+
+    @Transactional
+    public User signUp(UserSignUpRequest request) {
+        if (userRepository.existsByEmailAndIsQuit(request.getEmail(), false)) {
+            throw new AlreadyExistsException(USER_ALREADY_EXISTS);
+        }
+
+        //TODO: 이메일 인증 로직
+
+        User.validatePassword(request.getPassword());
+
+        User newUser = User.builder()
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .encodedPassword(passwordEncoder.encode(request.getPassword()))
+                .authority(Authority.USER)
+                .build();
+
+        return userRepository.save(newUser);
+    }
+
 }

--- a/src/main/java/com/swef/cookcode/user/service/UserSimpleService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserSimpleService.java
@@ -1,0 +1,22 @@
+package com.swef.cookcode.user.service;
+
+import static com.swef.cookcode.common.ErrorCode.USER_NOT_FOUND;
+
+import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSimpleService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User getUserById(Long userId) {
+        return userRepository.findByIdAndIsQuit(userId, false).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/swef/cookcode/user/service/UserSimpleService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserSimpleService.java
@@ -19,4 +19,9 @@ public class UserSimpleService {
     public User getUserById(Long userId) {
         return userRepository.findByIdAndIsQuit(userId, false).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
+
+    @Transactional(readOnly = true)
+    public boolean checkNicknameUnique(String nickname) {
+        return !userRepository.existsByNicknameAndIsQuit(nickname, false);
+    }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/account -> main

## 변경 사항
* 로그인 api 구현
* 회원가입 api 구현
* 유저 정보 조회 api 구현
* spring security를 활용하여 jwt 인증, 인가 코드 작성 

## 집중했으면 좋은 점
* 앞으로 api에서 인증된 사용자의 정보를 가져오기 위해서는 controller의 parameter 앞에 @CurrentUser annotation을 붙여주면 됩니다. (유저 정보 조회 api 참고)
```java
public ResponseEntity<ApiResponse<UserDetailResponse>> getUserInfo(@CurrentUser User user, @PathVariable("userId") Long userId) {
}
```
## 테스트 결과
### 회원가입 api
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/233862496-5e4be519-39fa-4508-a5a7-9b860135e0b9.png">

### 로그인 api
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/233862526-d9d1924d-e45d-4c55-a182-2c066d76afd5.png">

### 유저 정보 조회 api
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/233862569-0f4ee49d-26fa-46ca-8e39-18451509305f.png">

### 유저 정보 조회 api header 부분
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/233862609-51986792-121b-43ac-9c99-918d8a4093aa.png">

### 닉네임 중복확인 api
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/233864430-4510154b-69e2-4bd0-8fe7-7b9472c54af8.png">


