### PR TITLE
Recipe 정보 업로드 api 구현 완료

### DIFF
--- a/src/main/java/com/swef/cookcode/common/ErrorCode.java
+++ b/src/main/java/com/swef/cookcode/common/ErrorCode.java
@@ -40,7 +40,13 @@ public enum ErrorCode {
   TOKEN_USER_ID_NOT_MATCHED(400, "U016", "액세스 토큰과 유저 아이디가 매치되지 않습니다."),
   BLACKLIST_TOKEN_REQUEST(400, "U017", "로그아웃 처리된 토큰으로 요청할 수 없습니다."),
   OAUTH_EMAIL_REQUIRED(500, "U019", "OAuth email을 수집하는데 실패하였습니다."),
-  USER_NOT_ALLOWED(400, "U020", "해당 유저는 권한이 없습니다.");
+  USER_NOT_ALLOWED(400, "U020", "해당 유저는 권한이 없습니다."),
+
+  /*
+  Ingredient Domain
+   */
+
+  INGREDIENT_NOT_FOUND(400, "I001", "존재하지 않는 재료입니다.");
 
 
   private final int status;

--- a/src/main/java/com/swef/cookcode/fridge/dto/IngredientSimpleResponse.java
+++ b/src/main/java/com/swef/cookcode/fridge/dto/IngredientSimpleResponse.java
@@ -1,0 +1,20 @@
+package com.swef.cookcode.fridge.dto;
+
+import com.swef.cookcode.fridge.domain.Ingredient;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IngredientSimpleResponse {
+    private Long ingredientId;
+
+    private String name;
+
+    public static IngredientSimpleResponse from(Ingredient ingredient) {
+        return IngredientSimpleResponse.builder()
+                .ingredientId(ingredient.getId())
+                .name(ingredient.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/swef/cookcode/fridge/repository/IngredientRepository.java
+++ b/src/main/java/com/swef/cookcode/fridge/repository/IngredientRepository.java
@@ -1,0 +1,7 @@
+package com.swef.cookcode.fridge.repository;
+
+import com.swef.cookcode.fridge.domain.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+}

--- a/src/main/java/com/swef/cookcode/fridge/service/IngredientSimpleService.java
+++ b/src/main/java/com/swef/cookcode/fridge/service/IngredientSimpleService.java
@@ -1,0 +1,25 @@
+package com.swef.cookcode.fridge.service;
+
+import com.swef.cookcode.common.ErrorCode;
+import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.fridge.domain.Ingredient;
+import com.swef.cookcode.fridge.repository.IngredientRepository;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientSimpleService {
+
+    private final IngredientRepository ingredientRepository;
+
+    public List<Ingredient> getIngredientsByIds(List<Long> ids) {
+        try{
+            return ingredientRepository.findAllById(ids);
+        } catch(IllegalArgumentException exception) {
+            throw new NotFoundException(ErrorCode.INGREDIENT_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/swef/cookcode/fridge/service/IngredientSimpleService.java
+++ b/src/main/java/com/swef/cookcode/fridge/service/IngredientSimpleService.java
@@ -4,7 +4,6 @@ import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.fridge.domain.Ingredient;
 import com.swef.cookcode.fridge.repository.IngredientRepository;
-import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -9,6 +9,7 @@ import com.swef.cookcode.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +22,7 @@ public class RecipeController {
 
     private final RecipeService recipeService;
 
+    @PostMapping
     public ResponseEntity<ApiResponse<RecipeResponse>> createRecipe(@CurrentUser User user, @RequestBody RecipeCreateRequest recipeCreateRequest){
         // 레시피 서비스에서 레시피, 스텝 생성
         // s3에 삭제

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -1,7 +1,15 @@
 package com.swef.cookcode.recipe.controller;
 
+import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
+import com.swef.cookcode.recipe.dto.response.RecipeResponse;
 import com.swef.cookcode.recipe.service.RecipeService;
+import com.swef.cookcode.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,6 +21,17 @@ public class RecipeController {
 
     private final RecipeService recipeService;
 
+    public ResponseEntity<ApiResponse<RecipeResponse>> createRecipe(@CurrentUser User user, @RequestBody RecipeCreateRequest recipeCreateRequest){
+        // 레시피 서비스에서 레시피, 스텝 생성
+        // s3에 삭제
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("레시피 생성 성공")
+                .status(HttpStatus.CREATED.value())
+                .data(recipeService.createRecipe(user, recipeCreateRequest))
+                .build();
 
+        return ResponseEntity.ok()
+                .body(apiResponse);
+    }
 
 }

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -1,4 +1,18 @@
 package com.swef.cookcode.recipe.controller;
 
+import com.swef.cookcode.recipe.service.RecipeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/recipe")
+@RequiredArgsConstructor
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class RecipeController {
+
+    private final RecipeService recipeService;
+
+
+
 }

--- a/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -44,4 +45,13 @@ public class Recipe extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User author;
+
+    // TODO : Recipe Field Validation
+    @Builder
+    public Recipe(String title, String description, String thumbnail, User user) {
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
+        this.author = user;
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/domain/RecipeIngred.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/RecipeIngred.java
@@ -1,0 +1,52 @@
+package com.swef.cookcode.recipe.domain;
+
+import com.swef.cookcode.fridge.domain.Ingredient;
+import com.swef.cookcode.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "recipe_ingred",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "unq_ingred_recipe_ingred_id_recipe_id",
+                        columnNames = {"ingred_id", "recipe_id"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RecipeIngred {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_ingred_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id")
+    private Ingredient ingredient;
+
+    private Boolean isNecessary = true;
+
+    public RecipeIngred(Recipe recipe, Ingredient ingredient, Boolean isNecessary) {
+        this.ingredient = ingredient;
+        this.recipe = recipe;
+        this.isNecessary = isNecessary;
+    }
+}

--- a/src/main/java/com/swef/cookcode/recipe/domain/RecipeIngred.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/RecipeIngred.java
@@ -39,7 +39,7 @@ public class RecipeIngred {
     private Recipe recipe;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ingredient_id")
+    @JoinColumn(name = "ingred_id")
     private Ingredient ingredient;
 
     private Boolean isNecessary = true;

--- a/src/main/java/com/swef/cookcode/recipe/domain/Step.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/Step.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,4 +42,13 @@ public class Step extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id", nullable = false)
     private Recipe recipe;
+
+    // TODO : Step Field Validation
+    @Builder
+    public Step(Recipe recipe, Long seq, String title, String description) {
+        this.recipe = recipe;
+        this.seq = seq;
+        this.title = title;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/domain/StepPhoto.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/StepPhoto.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,4 +34,10 @@ public class StepPhoto extends BaseEntity {
 
     @Column(nullable = false, length = 300)
     private String photoUrl;
+
+    @Builder
+    public StepPhoto(Step step, String photoUrl){
+        this.step = step;
+        this.photoUrl = photoUrl;
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/domain/StepVideo.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/StepVideo.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,4 +35,10 @@ public class StepVideo extends BaseEntity {
 
     @Column(nullable = false, length = 300)
     private String videoUrl;
+
+    @Builder
+    public StepVideo(Step step, String videoUrl){
+        this.step = step;
+        this.videoUrl = videoUrl;
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.recipe.dto.request;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,9 +12,13 @@ public class RecipeCreateRequest {
 
     private String description;
 
-    private Long[] ingredients;
+    private List<Long> ingredients;
 
-    private Long[] optionalIngredients;
+    private List<Long> optionalIngredients;
 
-    private StepCreateRequest[] steps;
+    private List<StepCreateRequest> steps;
+
+    private String thumbnail;
+
+    private String deletedThumbnails;
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
@@ -1,0 +1,19 @@
+package com.swef.cookcode.recipe.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class RecipeCreateRequest {
+
+    private String title;
+
+    private String description;
+
+    private Long[] ingredients;
+
+    private Long[] optionalIngredients;
+
+    private StepCreateRequest[] steps;
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
@@ -20,5 +20,5 @@ public class RecipeCreateRequest {
 
     private String thumbnail;
 
-    private String deletedThumbnails;
+    private List<String> deletedThumbnails;
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/StepCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/StepCreateRequest.java
@@ -1,0 +1,23 @@
+package com.swef.cookcode.recipe.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class StepCreateRequest {
+
+    private Long seq;
+
+    private String title;
+
+    private String description;
+
+    private String[] videos;
+
+    private String[] photos;
+
+    private String[] deletedVideos;
+
+    private String[] deletedPhotos;
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/StepCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/StepCreateRequest.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.recipe.dto.request;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,11 +14,11 @@ public class StepCreateRequest {
 
     private String description;
 
-    private String[] videos;
+    private List<String> videos;
 
-    private String[] photos;
+    private List<String> photos;
 
-    private String[] deletedVideos;
+    private List<String> deletedVideos;
 
-    private String[] deletedPhotos;
+    private List<String> deletedPhotos;
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/PhotoResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/PhotoResponse.java
@@ -1,0 +1,12 @@
+package com.swef.cookcode.recipe.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PhotoResponse {
+    private Long stepPhotoId;
+
+    private String photoUrl;
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
@@ -1,0 +1,37 @@
+package com.swef.cookcode.recipe.dto.response;
+
+import com.swef.cookcode.fridge.dto.IngredientSimpleResponse;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecipeResponse {
+    private Long recipeId;
+
+    private UserSimpleResponse user;
+
+    private String title;
+
+    private String description;
+
+    private IngredientSimpleResponse[] ingredients;
+
+    private IngredientSimpleResponse[] optionalIngredients;
+
+    private StepResponse[] steps;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Boolean isLiked;
+
+    private Long likeCount;
+
+    private Long commentCount;
+
+    private String thumbnail;
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
@@ -3,6 +3,7 @@ package com.swef.cookcode.recipe.dto.response;
 import com.swef.cookcode.fridge.dto.IngredientSimpleResponse;
 import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,11 +18,11 @@ public class RecipeResponse {
 
     private String description;
 
-    private IngredientSimpleResponse[] ingredients;
+    private List<IngredientSimpleResponse> ingredients;
 
-    private IngredientSimpleResponse[] optionalIngredients;
+    private List<IngredientSimpleResponse> optionalIngredients;
 
-    private StepResponse[] steps;
+    private List<StepResponse> steps;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/StepResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/StepResponse.java
@@ -3,7 +3,7 @@ package com.swef.cookcode.recipe.dto.response;
 import com.swef.cookcode.recipe.domain.Step;
 import com.swef.cookcode.recipe.domain.StepPhoto;
 import com.swef.cookcode.recipe.domain.StepVideo;
-import java.util.Arrays;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,11 +18,11 @@ public class StepResponse {
 
     private String description;
 
-    private PhotoResponse[] photos;
+    private List<PhotoResponse> photos;
 
-    private VideoResponse[] videos;
+    private List<VideoResponse> videos;
 
-    public static StepResponse from(Step step, StepPhoto[] photos, StepVideo[] videos) {
+    public static StepResponse from(Step step, List<StepPhoto> photos, List<StepVideo> videos) {
         return StepResponse.builder()
                 .stepId(step.getId())
                 .seq(step.getSeq())
@@ -34,19 +34,20 @@ public class StepResponse {
     }
 
     // TODO : 중복코드 refactor
-    public static PhotoResponse[] photoFrom(StepPhoto[] photos) {
-        return (PhotoResponse[]) Arrays.stream(photos).map(photo ->
+    public static List<PhotoResponse> photoFrom(List<StepPhoto> photos) {
+        return photos.stream().map(photo ->
                         PhotoResponse.builder()
                                 .stepPhotoId(photo.getId())
-                                .photoUrl(photo.getPhotoUrl()))
-                .toArray();
+                                .photoUrl(photo.getPhotoUrl())
+                                .build())
+                .toList();
     }
 
-    public static VideoResponse[] videoFrom(StepVideo[] videos) {
-        return (VideoResponse[]) Arrays.stream(videos).map(video ->
+    public static List<VideoResponse> videoFrom(List<StepVideo> videos) {
+        return videos.stream().map(video ->
                         VideoResponse.builder()
                                 .stepVideoId(video.getId())
-                                .videoUrl(video.getVideoUrl()))
-                .toArray();
+                                .videoUrl(video.getVideoUrl()).build())
+                .toList();
     }
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/StepResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/StepResponse.java
@@ -1,0 +1,52 @@
+package com.swef.cookcode.recipe.dto.response;
+
+import com.swef.cookcode.recipe.domain.Step;
+import com.swef.cookcode.recipe.domain.StepPhoto;
+import com.swef.cookcode.recipe.domain.StepVideo;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StepResponse {
+    private Long stepId;
+
+    private Long seq;
+
+    private String title;
+
+    private String description;
+
+    private PhotoResponse[] photos;
+
+    private VideoResponse[] videos;
+
+    public static StepResponse from(Step step, StepPhoto[] photos, StepVideo[] videos) {
+        return StepResponse.builder()
+                .stepId(step.getId())
+                .seq(step.getSeq())
+                .title(step.getTitle())
+                .description(step.getDescription())
+                .photos(photoFrom(photos))
+                .videos(videoFrom(videos))
+                .build();
+    }
+
+    // TODO : 중복코드 refactor
+    public static PhotoResponse[] photoFrom(StepPhoto[] photos) {
+        return (PhotoResponse[]) Arrays.stream(photos).map(photo ->
+                        PhotoResponse.builder()
+                                .stepPhotoId(photo.getId())
+                                .photoUrl(photo.getPhotoUrl()))
+                .toArray();
+    }
+
+    public static VideoResponse[] videoFrom(StepVideo[] videos) {
+        return (VideoResponse[]) Arrays.stream(videos).map(video ->
+                        VideoResponse.builder()
+                                .stepVideoId(video.getId())
+                                .videoUrl(video.getVideoUrl()))
+                .toArray();
+    }
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/VideoResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/VideoResponse.java
@@ -1,0 +1,12 @@
+package com.swef.cookcode.recipe.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class VideoResponse {
+    private Long stepVideoId;
+
+    private String videoUrl;
+}

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeIngredRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeIngredRepository.java
@@ -1,0 +1,7 @@
+package com.swef.cookcode.recipe.repository;
+
+import com.swef.cookcode.recipe.domain.RecipeIngred;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeIngredRepository extends JpaRepository<RecipeIngred, Long> {
+}

--- a/src/main/java/com/swef/cookcode/recipe/repository/StepPhotoRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/StepPhotoRepository.java
@@ -1,0 +1,7 @@
+package com.swef.cookcode.recipe.repository;
+
+import com.swef.cookcode.recipe.domain.StepPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StepPhotoRepository extends JpaRepository<StepPhoto, Long> {
+}

--- a/src/main/java/com/swef/cookcode/recipe/repository/StepRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/StepRepository.java
@@ -1,0 +1,7 @@
+package com.swef.cookcode.recipe.repository;
+
+import com.swef.cookcode.recipe.domain.Step;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StepRepository extends JpaRepository<Step, Long> {
+}

--- a/src/main/java/com/swef/cookcode/recipe/repository/StepVideoRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/StepVideoRepository.java
@@ -1,0 +1,7 @@
+package com.swef.cookcode.recipe.repository;
+
+import com.swef.cookcode.recipe.domain.StepVideo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StepVideoRepository extends JpaRepository<StepVideo, Long> {
+}

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -11,6 +11,7 @@ import com.swef.cookcode.recipe.dto.response.StepResponse;
 import com.swef.cookcode.recipe.repository.RecipeIngredRepository;
 import com.swef.cookcode.recipe.repository.RecipeRepository;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import com.swef.cookcode.user.service.UserSimpleService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,8 @@ public class RecipeService {
                 .thumbnail(request.getThumbnail())
                 .build();
         Recipe savedRecipe = recipeRepository.save(newRecipe);
+
+        // TODO : 필수 재료이면서 선택 재료인 것들에 대해 예외 처리하는 비즈니스 로직 추가 필요
         List<Ingredient> requiredIngredients = ingredientSimpleService.getIngredientsByIds(request.getIngredients());
         List<Ingredient> optionalIngredients = ingredientSimpleService.getIngredientsByIds(request.getOptionalIngredients());
         List<IngredientSimpleResponse> ingredResponses = requiredIngredients.stream().map(
@@ -60,10 +63,10 @@ public class RecipeService {
                 .ingredients(ingredResponses)
                 .optionalIngredients(optionalIngredResponses)
                 .steps(stepResponses)
+                .user(UserSimpleResponse.from(currentUser))
                 .build();
     }
 
-    // validation 해당 서비스에서만 사용하는 함수로 만듦으로써 validation은 호출부에서 한다고 가정
     @Transactional
     void saveIngredientsOfRecipe(Recipe recipe, List<Ingredient> ingredients, Boolean isNecessary) {
         List<RecipeIngred> recipeIngredList = ingredients.stream()

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -40,13 +40,15 @@ public class RecipeService {
         Recipe savedRecipe = recipeRepository.save(newRecipe);
         List<Ingredient> requiredIngredients = ingredientSimpleService.getIngredientsByIds(request.getIngredients());
         List<Ingredient> optionalIngredients = ingredientSimpleService.getIngredientsByIds(request.getOptionalIngredients());
-        saveIngredientsOfRecipe(savedRecipe, requiredIngredients, true);
-        saveIngredientsOfRecipe(savedRecipe, optionalIngredients, false);
-        List<StepResponse> stepResponses = stepService.saveStepsForRecipe(savedRecipe, request.getSteps());
         List<IngredientSimpleResponse> ingredResponses = requiredIngredients.stream().map(
                 IngredientSimpleResponse::from).toList();
         List<IngredientSimpleResponse> optionalIngredResponses = optionalIngredients.stream().map(
                 IngredientSimpleResponse::from).toList();
+
+        saveIngredientsOfRecipe(savedRecipe, requiredIngredients, true);
+        saveIngredientsOfRecipe(savedRecipe, optionalIngredients, false);
+
+        List<StepResponse> stepResponses = stepService.saveStepsForRecipe(savedRecipe, request.getSteps());
 
         return RecipeResponse.builder()
                 .recipeId(savedRecipe.getId())

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -1,4 +1,7 @@
 package com.swef.cookcode.recipe.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class RecipeService {
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -1,10 +1,7 @@
 package com.swef.cookcode.recipe.service;
 
-import com.swef.cookcode.common.ErrorCode;
-import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.fridge.domain.Ingredient;
 import com.swef.cookcode.fridge.dto.IngredientSimpleResponse;
-import com.swef.cookcode.fridge.repository.IngredientRepository;
 import com.swef.cookcode.fridge.service.IngredientSimpleService;
 import com.swef.cookcode.recipe.domain.Recipe;
 import com.swef.cookcode.recipe.domain.RecipeIngred;
@@ -15,9 +12,7 @@ import com.swef.cookcode.recipe.repository.RecipeIngredRepository;
 import com.swef.cookcode.recipe.repository.RecipeRepository;
 import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.service.UserSimpleService;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -1,7 +1,76 @@
 package com.swef.cookcode.recipe.service;
 
+import com.swef.cookcode.common.ErrorCode;
+import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.fridge.domain.Ingredient;
+import com.swef.cookcode.fridge.dto.IngredientSimpleResponse;
+import com.swef.cookcode.fridge.repository.IngredientRepository;
+import com.swef.cookcode.fridge.service.IngredientSimpleService;
+import com.swef.cookcode.recipe.domain.Recipe;
+import com.swef.cookcode.recipe.domain.RecipeIngred;
+import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
+import com.swef.cookcode.recipe.dto.response.RecipeResponse;
+import com.swef.cookcode.recipe.dto.response.StepResponse;
+import com.swef.cookcode.recipe.repository.RecipeIngredRepository;
+import com.swef.cookcode.recipe.repository.RecipeRepository;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserSimpleService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class RecipeService {
+
+    private final RecipeRepository recipeRepository;
+
+    private final RecipeIngredRepository recipeIngredRepository;
+    private final UserSimpleService userSimpleService;
+
+    private final StepService stepService;
+    private final IngredientSimpleService ingredientSimpleService;
+
+    @Transactional
+    public RecipeResponse createRecipe(User currentUser, RecipeCreateRequest request) {
+        Recipe newRecipe = Recipe.builder()
+                .user(currentUser)
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .thumbnail(request.getThumbnail())
+                .build();
+        Recipe savedRecipe = recipeRepository.save(newRecipe);
+        List<Ingredient> requiredIngredients = ingredientSimpleService.getIngredientsByIds(request.getIngredients());
+        List<Ingredient> optionalIngredients = ingredientSimpleService.getIngredientsByIds(request.getOptionalIngredients());
+        saveIngredientsOfRecipe(savedRecipe, requiredIngredients, true);
+        saveIngredientsOfRecipe(savedRecipe, optionalIngredients, false);
+        List<StepResponse> stepResponses = stepService.saveStepsForRecipe(savedRecipe, request.getSteps());
+        List<IngredientSimpleResponse> ingredResponses = requiredIngredients.stream().map(
+                IngredientSimpleResponse::from).toList();
+        List<IngredientSimpleResponse> optionalIngredResponses = optionalIngredients.stream().map(
+                IngredientSimpleResponse::from).toList();
+
+        return RecipeResponse.builder()
+                .recipeId(savedRecipe.getId())
+                .title(savedRecipe.getTitle())
+                .description(savedRecipe.getDescription())
+                .thumbnail(savedRecipe.getThumbnail())
+                .createdAt(savedRecipe.getCreatedAt())
+                .updatedAt(savedRecipe.getUpdatedAt())
+                .ingredients(ingredResponses)
+                .optionalIngredients(optionalIngredResponses)
+                .steps(stepResponses)
+                .build();
+    }
+
+    // validation 해당 서비스에서만 사용하는 함수로 만듦으로써 validation은 호출부에서 한다고 가정
+    @Transactional
+    void saveIngredientsOfRecipe(Recipe recipe, List<Ingredient> ingredients, Boolean isNecessary) {
+        List<RecipeIngred> recipeIngredList = ingredients.stream()
+                .map(ingredient -> new RecipeIngred(recipe, ingredient, isNecessary)).toList();
+        recipeIngredRepository.saveAll(recipeIngredList);
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/StepService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/StepService.java
@@ -1,7 +1,6 @@
 package com.swef.cookcode.recipe.service;
 
 import com.swef.cookcode.recipe.domain.Recipe;
-import com.swef.cookcode.recipe.domain.RecipeIngred;
 import com.swef.cookcode.recipe.domain.Step;
 import com.swef.cookcode.recipe.domain.StepPhoto;
 import com.swef.cookcode.recipe.domain.StepVideo;
@@ -11,9 +10,7 @@ import com.swef.cookcode.recipe.repository.StepPhotoRepository;
 import com.swef.cookcode.recipe.repository.StepRepository;
 import com.swef.cookcode.recipe.repository.StepVideoRepository;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/swef/cookcode/recipe/service/StepService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/StepService.java
@@ -1,0 +1,69 @@
+package com.swef.cookcode.recipe.service;
+
+import com.swef.cookcode.recipe.domain.Recipe;
+import com.swef.cookcode.recipe.domain.RecipeIngred;
+import com.swef.cookcode.recipe.domain.Step;
+import com.swef.cookcode.recipe.domain.StepPhoto;
+import com.swef.cookcode.recipe.domain.StepVideo;
+import com.swef.cookcode.recipe.dto.request.StepCreateRequest;
+import com.swef.cookcode.recipe.dto.response.StepResponse;
+import com.swef.cookcode.recipe.repository.StepPhotoRepository;
+import com.swef.cookcode.recipe.repository.StepRepository;
+import com.swef.cookcode.recipe.repository.StepVideoRepository;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StepService {
+    private final StepRepository stepRepository;
+
+    private final StepPhotoRepository stepPhotoRepository;
+
+    private final StepVideoRepository stepVideoRepository;
+
+    @Transactional
+    public List<StepResponse> saveStepsForRecipe(Recipe recipe, List<StepCreateRequest> stepRequests) {
+        List<StepResponse> responses = new ArrayList<>();
+        stepRequests.forEach(request -> {
+            Step step = Step.builder()
+                    .title(request.getTitle())
+                    .description(request.getDescription())
+                    .seq(request.getSeq())
+                    .recipe(recipe)
+                    .build();
+            Step savedStep = stepRepository.save(step);
+            List<StepPhoto> savedPhotos = savePhotoUrlsForStep(savedStep, request.getPhotos());
+            List<StepVideo> savedVideos = saveVideoUrlsForStep(savedStep, request.getVideos());
+            responses.add(StepResponse.from(savedStep, savedPhotos, savedVideos));
+        });
+        return responses;
+    }
+
+    @Transactional
+    List<StepPhoto> savePhotoUrlsForStep(Step step, List<String> photos) {
+        List<StepPhoto> stepPhotos = photos.stream().map(url ->
+                StepPhoto.builder()
+                .step(step)
+                .photoUrl(url)
+                .build()
+        ).toList();
+        return stepPhotoRepository.saveAll(stepPhotos);
+    }
+
+    @Transactional
+    List<StepVideo> saveVideoUrlsForStep(Step step, List<String> videos) {
+        List<StepVideo> stepVideos = videos.stream().map(url ->
+                StepVideo.builder()
+                        .step(step)
+                        .videoUrl(url)
+                        .build()
+        ).toList();
+        return stepVideoRepository.saveAll(stepVideos);
+    }
+}

--- a/src/main/java/com/swef/cookcode/user/dto/response/UserSimpleResponse.java
+++ b/src/main/java/com/swef/cookcode/user/dto/response/UserSimpleResponse.java
@@ -1,0 +1,25 @@
+package com.swef.cookcode.user.dto.response;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import com.swef.cookcode.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSimpleResponse {
+    private Long userId;
+
+    private String profileImage;
+
+    private String nickname;
+
+    public static UserSimpleResponse from(User user) {
+        return UserSimpleResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(hasText(user.getProfileImage()) ? user.getProfileImage() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -14,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNicknameAndIsQuit(@Param("nickname") String nickname, @Param("isQuit") Boolean isQuit);
 
+    boolean existsByIdAndIsQuit(@Param("userId") Long userId, @Param("isQuit") Boolean isQuit);
 }

--- a/src/main/java/com/swef/cookcode/user/service/UserSimpleService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserSimpleService.java
@@ -24,4 +24,9 @@ public class UserSimpleService {
     public boolean checkNicknameUnique(String nickname) {
         return !userRepository.existsByNicknameAndIsQuit(nickname, false);
     }
+
+    @Transactional(readOnly = true)
+    public boolean checkUserExists(Long userId) {
+        return userRepository.existsByIdAndIsQuit(userId, false);
+    }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/recipe -> main

## 변경 사항
* recipe 정보 업로드 api 구현을 완료했습니다.

## 집중했으면 좋은 점
* step은 recipe에 완전히 종속적인 관계이기 때문에 recipe service가 step service를 참조하도록 하였습니다.
* 처음에 dto에서 여러 요소들을 받을 때 array로 받았으나, repository등 jpa를 사용할 때 list로 반환되어 list를 활용하기 때문에 dto의 array type을 list로 변경했습니다.
* 여러 개를 insert할 때는 반복문을 돌며 save를 하기 보다 saveAll을 했지만, step에 해당하는 사진들과 영상들을 저장할 때 stepId가 필요하여, recipe save -> step save -> 사진 saveAll, 영상 saveAll
* 필수 재료와 선택 재료가 겹칠 때에 예외 처리 로직은 아직 처리하지 않았습니다.

## 테스트 결과
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/234807892-9bc1a39a-7916-490d-9029-b7b1ba40bdb2.png">
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/234807956-aa4380bd-d2c4-4836-bd39-008f5bad4f67.png">
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/52846807/234808079-2be5944d-dcd1-44c4-a6b1-7901b2f7d530.png">

