### PR TITLE
계정 삭제 api 구현 완료

### DIFF
--- a/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swef/cookcode/common/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import static org.springframework.util.StringUtils.hasText;
 
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.swef.cookcode.common.error.exception.AuthErrorException;
+import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.common.jwt.claims.AccessClaim;
 import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.service.UserSimpleService;
@@ -56,6 +57,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);
           }
+        } catch (NotFoundException e) {
+          log.warn("탈퇴한 유저의 토큰입니다. token: {}", token);
+          throw e;
         } catch (TokenExpiredException e) {
           log.warn("토큰이 만료된 요청입니다. token: {}", token);
           throw e;

--- a/src/main/java/com/swef/cookcode/fridge/repository/FridgeIngredientRepository.java
+++ b/src/main/java/com/swef/cookcode/fridge/repository/FridgeIngredientRepository.java
@@ -2,6 +2,7 @@ package com.swef.cookcode.fridge.repository;
 
 import com.swef.cookcode.fridge.domain.FridgeIngredient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,4 +12,8 @@ public interface FridgeIngredientRepository extends JpaRepository<FridgeIngredie
 
     @Query("SELECT fi FROM FridgeIngredient fi JOIN FETCH fi.ingred WHERE fi.fridge.id = :fridgeId")
     List<FridgeIngredient> findByFridgeId(@Param("fridgeId") Long fridgeId);
+
+    @Modifying
+    @Query("delete from FridgeIngredient fi where fi.fridge.id = :fridgeId")
+    void deleteByFridgeId(@Param("fridgeId") Long fridgeId);
 }

--- a/src/main/java/com/swef/cookcode/fridge/service/FridgeService.java
+++ b/src/main/java/com/swef/cookcode/fridge/service/FridgeService.java
@@ -1,5 +1,7 @@
 package com.swef.cookcode.fridge.service;
 
+import com.swef.cookcode.common.ErrorCode;
+import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.fridge.domain.Fridge;
 import com.swef.cookcode.fridge.domain.FridgeIngredient;
@@ -13,6 +15,7 @@ import com.swef.cookcode.user.domain.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.NotFound;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +71,13 @@ public class FridgeService {
     @Transactional
     public void deleteIngredOfFridge(Long fridgeIngredId) {
         fridgeIngredientRepository.deleteById(fridgeIngredId);
+    }
+
+    @Transactional
+    public void deleteFridgeOfUser(User user) {
+        Fridge fridge = fridgeRepository.findByOwner(user).orElseThrow(() -> new NotFoundException(FRIDGE_NOT_FOUND));
+        fridgeIngredientRepository.deleteByFridgeId(fridge.getId());
+        fridgeRepository.deleteById(fridge.getId());
     }
 
     @Transactional

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -27,7 +27,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -103,11 +105,21 @@ public class AccountController {
     public ResponseEntity<ApiResponse<UserDetailResponse>> getUserInfo(@CurrentUser User user, @PathVariable("userId") Long userId) {
         User returnedUser = userSimpleService.getUserById(userId);
         UserDetailResponse res = UserDetailResponse.from(returnedUser);
-        log.info("user {} get info of user {}", user.getNickname(), returnedUser.getNickname());
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("유저 정보 조회 성공")
-                .status(CREATED.value())
+                .status(OK.value())
                 .data(res)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse<UserDetailResponse>> quit(@CurrentUser User user) {
+        User returnedUser = userService.quit(user);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("계정 삭제 성공")
+                .status(OK.value())
+                .data(UserDetailResponse.from(returnedUser))
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -116,6 +116,7 @@ public class AccountController {
     @PatchMapping
     public ResponseEntity<ApiResponse<UserDetailResponse>> quit(@CurrentUser User user) {
         User returnedUser = userService.quit(user);
+        fridgeService.deleteFridgeOfUser(returnedUser);
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("계정 삭제 성공")
                 .status(OK.value())

--- a/src/main/java/com/swef/cookcode/user/domain/Status.java
+++ b/src/main/java/com/swef/cookcode/user/domain/Status.java
@@ -3,5 +3,6 @@ package com.swef.cookcode.user.domain;
 public enum Status {
     BLOCKED,
     VALID,
-    INF_REQUESTED
+    INF_REQUESTED,
+    QUIT
 }

--- a/src/main/java/com/swef/cookcode/user/domain/User.java
+++ b/src/main/java/com/swef/cookcode/user/domain/User.java
@@ -126,4 +126,9 @@ public class User extends BaseEntity {
         validatePassword(rawPassword);
         this.password = passwordEncoder.encode(rawPassword);
     }
+
+    public void quit() {
+        this.isQuit = true;
+        this.status = Status.QUIT;
+    }
 }

--- a/src/main/java/com/swef/cookcode/user/domain/User.java
+++ b/src/main/java/com/swef/cookcode/user/domain/User.java
@@ -131,4 +131,9 @@ public class User extends BaseEntity {
         this.isQuit = true;
         this.status = Status.QUIT;
     }
+
+    public void rejoin() {
+        this.isQuit = false;
+        this.status = Status.VALID;
+    }
 }

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -10,6 +10,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
 
+    Optional<User> findByEmail(@Param("email") String email);
+
     boolean existsByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
 
     boolean existsByNicknameAndIsQuit(@Param("nickname") String nickname, @Param("isQuit") Boolean isQuit);

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -37,8 +37,15 @@ public class UserService {
 
     @Transactional
     public User signUp(UserSignUpRequest request) {
-        if (userRepository.existsByEmailAndIsQuit(request.getEmail(), false)) {
-            throw new AlreadyExistsException(USER_ALREADY_EXISTS);
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            User existUser = userRepository.findByEmail(request.getEmail()).get();
+            if (existUser.getIsQuit()) {
+                existUser.rejoin();
+                return userRepository.save(existUser);
+            }
+            else {
+                throw new AlreadyExistsException(USER_ALREADY_EXISTS);
+            }
         }
 
         //TODO: 이메일 인증 로직
@@ -58,6 +65,7 @@ public class UserService {
     @Transactional
     public User quit(User user) {
         user.quit();
+        userRepository.save(user);
         return user;
     }
 

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -55,4 +55,10 @@ public class UserService {
         return userRepository.save(newUser);
     }
 
+    @Transactional
+    public User quit(User user) {
+        user.quit();
+        return user;
+    }
+
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/account -> main

## 변경 사항
* 계정 삭제 시, 유저의 isQuit과 status를 각각 true, Status.Quit으로 update합니다.
* fridgeService의 deleteFridgeOfUser 메소드 추가

## 집중했으면 좋은 점
* 계정 삭제 후, 다시 탈퇴한 계정으로 회원가입하면 탈퇴한 계정의 isQuit, status가 각각 false, Status.Valid로 update됩니다.
* 계정 삭제 시 유저의 냉장고를 삭제합니다. 

## 테스트 결과
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/52846807/236811586-3447c8f7-3e33-40d1-8373-85c48ee8bd4d.png">
