### PR TITLE
레시피 사진 업로드 관련 s3 모듈 적용

### DIFF
--- a/src/main/java/com/swef/cookcode/common/UrlResponse.java
+++ b/src/main/java/com/swef/cookcode/common/UrlResponse.java
@@ -1,0 +1,12 @@
+package com.swef.cookcode.common;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UrlResponse {
+
+    List<String> urls;
+}

--- a/src/main/java/com/swef/cookcode/common/Util.java
+++ b/src/main/java/com/swef/cookcode/common/Util.java
@@ -27,7 +27,6 @@ public class Util {
             throw new InvalidRequestException(ErrorCode.DUPLICATED);
         }
     }
-
     public UrlResponse uploadFilesToS3(String directory, List<MultipartFile> files) {
         List<String> urls = new ArrayList<>();
         files.forEach(file -> {
@@ -41,5 +40,8 @@ public class Util {
         return UrlResponse.builder()
                 .urls(urls)
                 .build();
+    }
+    public void deleteFilesInS3(List<String> urls) {
+        urls.forEach(s3Util::deleteFile);
     }
 }

--- a/src/main/java/com/swef/cookcode/common/Util.java
+++ b/src/main/java/com/swef/cookcode/common/Util.java
@@ -1,11 +1,23 @@
 package com.swef.cookcode.common;
 
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
+import com.swef.cookcode.common.util.S3Util;
+import com.swef.cookcode.recipe.domain.Recipe;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
+@Component
+@RequiredArgsConstructor
 public class Util {
+
+    private final S3Util s3Util;
+
     public static <T> void validateDuplication(List<T> list1, List<T> list2) {
         Set<T> mergedSets = new HashSet<>() {{
             addAll(list1);
@@ -14,5 +26,20 @@ public class Util {
         if (mergedSets.size() < list1.size() + list2.size()) {
             throw new InvalidRequestException(ErrorCode.DUPLICATED);
         }
+    }
+
+    public UrlResponse uploadFilesToS3(String directory, List<MultipartFile> files) {
+        List<String> urls = new ArrayList<>();
+        files.forEach(file -> {
+            try {
+                String path = s3Util.upload(file, Recipe.RECIPE_DIRECTORY_NAME);
+                urls.add(path);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return UrlResponse.builder()
+                .urls(urls)
+                .build();
     }
 }

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -2,12 +2,16 @@ package com.swef.cookcode.recipe.controller;
 
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.PageResponse;
+import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.recipe.domain.Recipe;
 import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeUpdateRequest;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
+import com.swef.cookcode.common.UrlResponse;
 import com.swef.cookcode.recipe.service.RecipeService;
 import com.swef.cookcode.user.domain.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,7 +26,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("api/v1/recipe")
@@ -31,6 +37,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecipeController {
 
     private final RecipeService recipeService;
+
+    private final Util util;
 
     @PostMapping
     public ResponseEntity<ApiResponse<RecipeResponse>> createRecipe(@CurrentUser User user, @RequestBody RecipeCreateRequest recipeCreateRequest){
@@ -41,6 +49,18 @@ public class RecipeController {
                 .data(recipeService.createRecipe(user, recipeCreateRequest))
                 .build();
 
+        return ResponseEntity.ok()
+                .body(apiResponse);
+    }
+
+    @PostMapping("/photos")
+    public ResponseEntity<ApiResponse<UrlResponse>> uploadRecipePhotos(@RequestPart(value = "stepImages") List<MultipartFile> files) {
+        UrlResponse response = util.uploadFilesToS3(Recipe.RECIPE_DIRECTORY_NAME, files);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("레시피 파일 업로드 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
         return ResponseEntity.ok()
                 .body(apiResponse);
     }

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -4,6 +4,7 @@ import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.PageResponse;
 import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.common.util.S3Util;
 import com.swef.cookcode.recipe.domain.Recipe;
 import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeUpdateRequest;
@@ -42,7 +43,9 @@ public class RecipeController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<RecipeResponse>> createRecipe(@CurrentUser User user, @RequestBody RecipeCreateRequest recipeCreateRequest){
-        // TODO : s3에 deleted url 삭제, thumbnail 등록
+
+        recipeService.deleteUnusedFiles(recipeCreateRequest);
+
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 생성 성공")
                 .status(HttpStatus.CREATED.value())
@@ -67,7 +70,9 @@ public class RecipeController {
 
     @PatchMapping("/{recipeId}")
     public ResponseEntity<ApiResponse<RecipeResponse>> updateRecipe(@CurrentUser User user, @PathVariable("recipeId") Long recipeId, @RequestBody RecipeUpdateRequest recipeUpdateRequest){
-        // TODO : s3에 deleted url 삭제, thumbnail 등록
+
+        recipeService.deleteUnusedFiles(recipeUpdateRequest);
+
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 수정 성공")
                 .status(HttpStatus.OK.value())

--- a/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
@@ -27,6 +27,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Recipe extends BaseEntity {
 
+    public static final String RECIPE_DIRECTORY_NAME = "recipe";
+
     private static final int MAX_TITLE_LENGTH = 30;
 
     private static final int MAX_DESCRIPTION_LENGTH = 500;

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCreateRequest.java
@@ -20,4 +20,6 @@ public class RecipeCreateRequest {
     protected List<StepCreateRequest> steps;
 
     protected String thumbnail;
+
+    protected List<String> deletedThumbnails;
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -4,6 +4,7 @@ import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.common.error.exception.PermissionDeniedException;
+import com.swef.cookcode.common.util.S3Util;
 import com.swef.cookcode.fridge.domain.Ingredient;
 import com.swef.cookcode.fridge.service.IngredientSimpleService;
 import com.swef.cookcode.recipe.domain.Recipe;

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -38,6 +38,8 @@ public class RecipeService {
     private final StepService stepService;
     private final IngredientSimpleService ingredientSimpleService;
 
+    private final Util util;
+
     // TODO : JPA List 연관관계 사용으로 refactoring
     @Transactional
     public RecipeResponse createRecipe(User user, RecipeCreateRequest request) {
@@ -82,6 +84,14 @@ public class RecipeService {
         return RecipeResponse.builder()
                 .recipeId(recipe.getId())
                 .build();
+    }
+
+    public void deleteUnusedFiles(RecipeCreateRequest request) {
+        util.deleteFilesInS3(request.getDeletedThumbnails());
+        request.getSteps().forEach(step -> {
+            util.deleteFilesInS3(step.getDeletedPhotos());
+            util.deleteFilesInS3(step.getDeletedVideos());
+        });
     }
 
     // TODO : Recipe fetch 할 때 validation 안되서 임의로 추가.


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/recipe-file-upload -> main

## 변경 사항
* 사진/영상 업로드 api 구현
* 레시피 정보 업로드 api에서 deletedThumbnails, 각 스텝에 해당하는 deletedVideos, deletedPhotos 파일들 s3에서 삭제
* 레시피 수정 api에서 위 내용 마찬가지로 적용
* 레시피 삭제 api에서 해당하는 url들에 대해서 s3에서 삭제

## 집중했으면 좋은 점
* Util에 S3Util을 di 받아서 전역적으로 사용할 수 있게 함
* 레시피 정보 업로드 api 시, s3에 있는 url인지에 대해서는 아직 validation 처리하지 않음.
