### PR TITLE
식재료 기반 레시피 필터링 구현

### DIFF
--- a/src/main/java/com/swef/cookcode/common/Util.java
+++ b/src/main/java/com/swef/cookcode/common/Util.java
@@ -30,6 +30,15 @@ public class Util {
             throw new InvalidRequestException(ErrorCode.DUPLICATED);
         }
     }
+
+    public static <T> boolean includesAll(List<T> list1, List<T> list2) {
+        if (list1.size() < list2.size()) return false;
+        for (T t : list2) {
+            if (!list1.contains(t)) return false;
+        }
+        return true;
+    }
+
     public UrlResponse uploadFilesToS3(String directory, List<MultipartFile> files) {
         List<String> urls = files.stream().map(file -> s3Util.upload(file, directory)).toList();
         return UrlResponse.builder()

--- a/src/main/java/com/swef/cookcode/fridge/service/FridgeService.java
+++ b/src/main/java/com/swef/cookcode/fridge/service/FridgeService.java
@@ -14,6 +14,7 @@ import com.swef.cookcode.fridge.repository.IngredientRepository;
 import com.swef.cookcode.user.domain.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.NotFound;
 import org.springframework.stereotype.Service;
@@ -75,9 +76,10 @@ public class FridgeService {
 
     @Transactional
     public void deleteFridgeOfUser(User user) {
-        Fridge fridge = fridgeRepository.findByOwner(user).orElseThrow(() -> new NotFoundException(FRIDGE_NOT_FOUND));
-        fridgeIngredientRepository.deleteByFridgeId(fridge.getId());
-        fridgeRepository.deleteById(fridge.getId());
+        Optional<Fridge> fridge = fridgeRepository.findByOwner(user);
+        if (fridge.isEmpty()) return;
+        fridgeIngredientRepository.deleteByFridgeId(fridge.get().getId());
+        fridgeRepository.deleteById(fridge.get().getId());
     }
 
     @Transactional

--- a/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
@@ -92,4 +92,12 @@ public class Recipe extends BaseEntity {
         this.steps.clear();
     }
 
+    public List<RecipeIngred> getNecessaryIngredients() {
+        return ingredients.stream().filter(RecipeIngred::getIsNecessary).toList();
+    }
+
+    public List<RecipeIngred> getOptionalIngredients() {
+        return ingredients.stream().filter(ri -> !ri.getIsNecessary()).toList();
+    }
+
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
@@ -35,6 +35,7 @@ public class RecipeResponse {
     private LocalDateTime updatedAt;
 
     private Boolean isLiked;
+    private Boolean isCookable;
 
     private Long likeCount;
 
@@ -48,8 +49,8 @@ public class RecipeResponse {
                 .user(UserSimpleResponse.from(recipe.getAuthor()))
                 .title(recipe.getTitle())
                 .description(recipe.getDescription())
-                .ingredients(filterNecessaryIngredient(recipe.getIngredients()))
-                .optionalIngredients(filterOptionalIngredient(recipe.getIngredients()))
+                .ingredients(convert(recipe.getNecessaryIngredients()))
+                .optionalIngredients(convert(recipe.getOptionalIngredients()))
                 .steps(recipe.getSteps().stream().map(s -> StepResponse.from(s, s.getPhotos(), s.getVideos())).toList())
                 .createdAt(recipe.getCreatedAt())
                 .updatedAt(recipe.getUpdatedAt())
@@ -63,19 +64,19 @@ public class RecipeResponse {
                 .user(UserSimpleResponse.from(recipe.getAuthor()))
                 .title(recipe.getTitle())
                 .description(recipe.getDescription())
-                .ingredients(filterNecessaryIngredient(recipe.getIngredients()))
-                .optionalIngredients(filterOptionalIngredient(recipe.getIngredients()))
+                .ingredients(convert(recipe.getNecessaryIngredients()))
+                .optionalIngredients(convert(recipe.getOptionalIngredients()))
                 .createdAt(recipe.getCreatedAt())
                 .updatedAt(recipe.getUpdatedAt())
                 .thumbnail(recipe.getThumbnail())
                 .build();
     }
 
-    private static List<IngredSimpleResponse> filterNecessaryIngredient(List<RecipeIngred> ingreds) {
-        return ingreds.stream().filter(RecipeIngred::getIsNecessary).map(i -> IngredSimpleResponse.from(i.getIngredient())).toList();
+    private static List<IngredSimpleResponse> convert(List<RecipeIngred> ingreds) {
+        return ingreds.stream().map(i -> IngredSimpleResponse.from(i.getIngredient())).toList();
     }
 
-    private static List<IngredSimpleResponse> filterOptionalIngredient(List<RecipeIngred> ingreds) {
-        return ingreds.stream().filter(i -> !i.getIsNecessary()).map(i -> IngredSimpleResponse.from(i.getIngredient())).toList();
+    public void setIsCookable(Boolean isCookable) {
+        this.isCookable = isCookable;
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/cookable-recipe -> main

## 변경 사항
* 레시피 다건조회시 cookable을 true로 보낼 때, 사용자가 가진 식재료 기반 요리할 수 있는 레시피만 보내줍니다.
* cookable을 null로 보내거나, false로 보내면 요리할 수 있던 없던 모두 보내주되, isCookable flag 정보를 제공하여 요리할 수 있는지 아닌지 표시합니다.

### 기타 변경사항
* 계정 삭제 시 냉장고가 없는 상황이더라도 탈퇴 처리 가능하도록 함.
* 레시피의 필수재료 선택재료를 필터링하는 로직을 RecipeResponse -> Recipe로 옮기고 response에는 dto로 형변환하는 것만 두는 것으로 리팩토링 

## 집중했으면 좋은 점
* JPA와 쿼리를 사용하여 db에서 데이터를 가지고 올 수도 있을 것 같은데 일단 가지고 온 데이터에 대해서 필터링하는 식으로 구현함
* 개수가 정해진 데이터들에 대한 필터링이라 성능상 문제가 생기지는 않을 것 같음.
* 추후 JPA로 가지고 오는 법 또한 찾아보겠음

## 테스트 결과
<img width="1132" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/d459e5e8-8610-41bf-8e18-460d0952e186">
