### PR TITLE
Cookie 조회 구현

### DIFF
--- a/src/main/java/com/swef/cookcode/common/ErrorCode.java
+++ b/src/main/java/com/swef/cookcode/common/ErrorCode.java
@@ -67,7 +67,14 @@ public enum ErrorCode {
   /*
   Recipe Domain
    */
-  RECIPE_NOT_FOUND(400, "I001", "존재하지 않는 레시피입니다.");
+  RECIPE_NOT_FOUND(400, "I001", "존재하지 않는 레시피입니다."),
+
+  /*
+  Cookie Domain
+   */
+  COOKIE_NOT_FOUND(400, "K001", "존재하지 않는 쿠키입니다.");
+
+
 
   private final int status;
   private final String code;

--- a/src/main/java/com/swef/cookcode/common/SliceResponse.java
+++ b/src/main/java/com/swef/cookcode/common/SliceResponse.java
@@ -1,0 +1,21 @@
+package com.swef.cookcode.common;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+public class SliceResponse<T> {
+  private final List<T> content;
+  private final int numberOfElements;
+  private final boolean hasNext;
+
+  @Builder
+  public SliceResponse(Slice<T> slice) {
+    this.content = slice.getContent();
+    this.numberOfElements = slice.getNumberOfElements();
+    this.hasNext = slice.hasNext();
+  }
+}

--- a/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
+++ b/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
@@ -1,4 +1,62 @@
 package com.swef.cookcode.cookie.controller;
 
+import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.SliceResponse;
+import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.cookie.domain.Cookie;
+import com.swef.cookcode.cookie.dto.CookieResponse;
+import com.swef.cookcode.cookie.service.CookieService;
+import com.swef.cookcode.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/v1/cookie")
+@RequiredArgsConstructor
 public class CookieController {
+
+    private final CookieService cookieService;
+
+    private final int COOKIE_SLICE_SIZE = 5;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getCookie(
+            @CurrentUser User user,  @PageableDefault(size = COOKIE_SLICE_SIZE) Pageable pageable){
+
+        Slice<Cookie> cookieSlice = cookieService.getCookies(pageable);
+        Slice<CookieResponse> cookieRsponseSlice = cookieSlice.map(CookieResponse::of);
+
+        SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieRsponseSlice);
+
+        ApiResponse response = ApiResponse.builder()
+                .message("쿠키 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(sliceResponse)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{cookieId}")
+    public ResponseEntity<ApiResponse<CookieResponse>> getCookieById(
+            @CurrentUser User user, @PathVariable Long cookieId){
+
+        Cookie cookie = cookieService.getCookieById(cookieId);
+
+        CookieResponse data = CookieResponse.of(cookie);
+
+        ApiResponse response = ApiResponse.builder()
+                .message("쿠키 단건 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(data)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
+++ b/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,13 +27,13 @@ public class CookieController {
     private final int COOKIE_SLICE_SIZE = 5;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getCookie(
-            @CurrentUser User user,  @PageableDefault(size = COOKIE_SLICE_SIZE) Pageable pageable){
+    public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getRandomCookies(
+            @PageableDefault(size = COOKIE_SLICE_SIZE) Pageable pageable){
 
-        Slice<Cookie> cookieSlice = cookieService.getCookies(pageable);
-        Slice<CookieResponse> cookieRsponseSlice = cookieSlice.map(CookieResponse::of);
+        Slice<Cookie> cookieSlice = cookieService.getRandomCookies(pageable);
+        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(CookieResponse::of);
 
-        SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieRsponseSlice);
+        SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieResponseSlice);
 
         ApiResponse response = ApiResponse.builder()
                 .message("쿠키 조회 성공")
@@ -45,7 +46,7 @@ public class CookieController {
 
     @GetMapping("/{cookieId}")
     public ResponseEntity<ApiResponse<CookieResponse>> getCookieById(
-            @CurrentUser User user, @PathVariable Long cookieId){
+            @PathVariable Long cookieId){
 
         Cookie cookie = cookieService.getCookieById(cookieId);
 
@@ -55,6 +56,25 @@ public class CookieController {
                 .message("쿠키 단건 조회 성공")
                 .status(HttpStatus.OK.value())
                 .data(data)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getCookiesOfUser(
+            @PathVariable Long userId,
+            @PageableDefault(size = COOKIE_SLICE_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+
+        Slice<Cookie> cookieSlice = cookieService.getCookiesOfUser(pageable, userId);
+        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(CookieResponse::of);
+
+        SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieResponseSlice);
+
+        ApiResponse response = ApiResponse.builder()
+                .message("유저의 쿠키 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(sliceResponse)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
+++ b/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
@@ -1,0 +1,20 @@
+package com.swef.cookcode.cookie.dto;
+
+import com.swef.cookcode.cookie.domain.Cookie;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CookieResponse {
+
+    private final String title;
+
+    private final String desc;
+
+    private final String videoUrl;
+
+    public static CookieResponse of(Cookie cookie){
+        return new CookieResponse(cookie.getTitle(), cookie.getDescription(), cookie.getVideoUrl());
+    }
+}

--- a/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
+++ b/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @Builder
 public class CookieResponse {
 
+    private final Long id;
+
     private final String title;
 
     private final String desc;
@@ -15,6 +17,6 @@ public class CookieResponse {
     private final String videoUrl;
 
     public static CookieResponse of(Cookie cookie){
-        return new CookieResponse(cookie.getTitle(), cookie.getDescription(), cookie.getVideoUrl());
+        return new CookieResponse(cookie.getId(), cookie.getTitle(), cookie.getDescription(), cookie.getVideoUrl());
     }
 }

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
@@ -8,5 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CookieRepository extends JpaRepository<Cookie, Long> {
     @Query(value = "SELECT * FROM Cookie ORDER BY RAND()", nativeQuery = true)
-    Slice<Cookie> findCookies(Pageable pageable);
+    Slice<Cookie> findRandomCookies(Pageable pageable);
+
+    @Query(value = "SELECT c FROM Cookie c WHERE c.user.id = :userId")
+    Slice<Cookie> findByUserId(Pageable pageable, Long userId);
 }

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
@@ -1,7 +1,12 @@
 package com.swef.cookcode.cookie.repository;
 
 import com.swef.cookcode.cookie.domain.Cookie;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CookieRepository extends JpaRepository<Cookie, Long> {
+    @Query(value = "SELECT * FROM Cookie ORDER BY RAND()", nativeQuery = true)
+    Slice<Cookie> findCookies(Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
+++ b/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
@@ -19,13 +19,18 @@ public class CookieService {
     private final CookieRepository cookieRepository;
 
     @Transactional
-    public Slice<Cookie> getCookies(Pageable pageable) {
-        return cookieRepository.findCookies(pageable);
+    public Slice<Cookie> getRandomCookies(Pageable pageable) {
+        return cookieRepository.findRandomCookies(pageable);
     }
 
     @Transactional
     public Cookie getCookieById(Long cookieId) {
         return cookieRepository.findById(cookieId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.COOKIE_NOT_FOUND));
+    }
+
+    @Transactional
+    public Slice<Cookie> getCookiesOfUser(Pageable pageable, Long userId) {
+        return cookieRepository.findByUserId(pageable, userId);
     }
 }

--- a/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
+++ b/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
@@ -1,4 +1,31 @@
 package com.swef.cookcode.cookie.service;
 
+import com.swef.cookcode.common.ErrorCode;
+import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.cookie.domain.Cookie;
+import com.swef.cookcode.cookie.dto.CookieResponse;
+import com.swef.cookcode.cookie.repository.CookieRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class CookieService {
+
+    private final CookieRepository cookieRepository;
+
+    @Transactional
+    public Slice<Cookie> getCookies(Pageable pageable) {
+        return cookieRepository.findCookies(pageable);
+    }
+
+    @Transactional
+    public Cookie getCookieById(Long cookieId) {
+        return cookieRepository.findById(cookieId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COOKIE_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/cookie-get -> main

## 변경 사항
쿠키 id로 조회, 쿠키 pagination(랜덤 기준) 조회 구현 
유저 id를 통한 유저의 쿠키 최신순 조회 구현

## 집중했으면 좋은 점
랜덤하게 조회하는 과정에서 매번 테이블 정렬이(랜덤하게) 발생,
정렬이 매번 랜덤하게 발생하여 다른 페이지 내 중복 데이터 생성 가능
-> 세션 데이터 사용시 방지 가능, 이후 성능과 데이터 특성을 고려하여 선택 예정