### PR TITLE
logback.xml 프로필에 따른 분리 수정 및 파일 업로드 api s3 폴더 지정

### DIFF
--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -56,11 +56,11 @@ public class RecipeController {
                 .body(apiResponse);
     }
 
-    @PostMapping("/files")
-    public ResponseEntity<ApiResponse<UrlResponse>> uploadRecipePhotos(@RequestPart(value = "stepFiles") List<MultipartFile> files) {
-        UrlResponse response = util.uploadFilesToS3(Recipe.RECIPE_DIRECTORY_NAME, files);
+    @PostMapping("/files/{directory}")
+    public ResponseEntity<ApiResponse<UrlResponse>> uploadRecipePhotos(@RequestPart(value = "stepFiles") List<MultipartFile> files, @PathVariable(value = "directory") String directory) {
+        UrlResponse response = util.uploadFilesToS3(directory, files);
         ApiResponse apiResponse = ApiResponse.builder()
-                .message("레시피 파일 업로드 성공")
+                .message("파일 업로드 성공")
                 .status(HttpStatus.OK.value())
                 .data(response)
                 .build();

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,11 +10,10 @@
 
     <springProperty name="AWS_ACCESS_KEY" source="aws.accessKey"/>
     <springProperty name="AWS_SECRET_KEY" source="aws.secretKey"/>
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <Pattern>${LOG_PATTERN}</Pattern>
-        </layout>
+        </encoder>
     </appender>
     <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -33,8 +32,15 @@
         <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
         <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
     </appender>
-    <root level="WARN">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="aws_cloud_watch_log"/>
-    </root>
+    <springProfile name="dev">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="aws_cloud_watch_log"/>
+        </root>
+    </springProfile>
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- refactor/file-and-log -> main

## 변경 사항
* local 프로필에서 aws-cloud-watch appender 로그가 실행되지 않도록 수정했습니다. 
* 파일 업로드 api에서 path variable로 s3에 올릴 directory 이름을 받도록 수정했습니다.

## 집중했으면 좋은 점
* logback.xml
* 파일 업로드 api

## 테스트 결과
