### PR TITLE
검색 기능(레시피, 사용자, 쿠키)과 쿠키 조회 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     // QueryDSL 설정
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    implementation 'com.querydsl:querydsl-sql:5.0.0'
     implementation 'com.querydsl:querydsl-apt'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'

--- a/src/main/java/com/swef/cookcode/common/Util.java
+++ b/src/main/java/com/swef/cookcode/common/Util.java
@@ -2,15 +2,13 @@ package com.swef.cookcode.common;
 
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.util.S3Util;
-import com.swef.cookcode.recipe.domain.Recipe;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -31,14 +29,6 @@ public class Util {
         }
     }
 
-    public static <T> boolean includesAll(List<T> list1, List<T> list2) {
-        if (list1.size() < list2.size()) return false;
-        for (T t : list2) {
-            if (!list1.contains(t)) return false;
-        }
-        return true;
-    }
-
     public UrlResponse uploadFilesToS3(String directory, List<MultipartFile> files) {
         List<String> urls = files.stream().map(file -> s3Util.upload(file, directory)).toList();
         return UrlResponse.builder()
@@ -47,5 +37,14 @@ public class Util {
     }
     public void deleteFilesInS3(List<String> urls) {
         urls.forEach(s3Util::deleteFile);
+    }
+
+    public static <T> boolean hasNextInSlice(List<T> result, Pageable pageable) {
+        boolean hasNext = false;
+        if (result.size() > pageable.getPageSize()) {
+            result.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return hasNext;
     }
 }

--- a/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
+++ b/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
@@ -9,6 +9,7 @@ import com.swef.cookcode.cookie.dto.CookiePatchRequest;
 import com.swef.cookcode.cookie.dto.CookieResponse;
 import com.swef.cookcode.cookie.service.CookieService;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserSimpleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -24,18 +25,21 @@ import static org.springframework.http.HttpStatus.OK;
 @RestController
 @RequestMapping("api/v1/cookie")
 @RequiredArgsConstructor
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class CookieController {
 
     private final CookieService cookieService;
+
+    private final UserSimpleService userSimpleService;
 
     private final int COOKIE_SLICE_SIZE = 5;
 
     @GetMapping
     public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getRandomCookies(
-            @PageableDefault(size = COOKIE_SLICE_SIZE) Pageable pageable){
+            @PageableDefault(size = COOKIE_SLICE_SIZE) Pageable pageable, @CurrentUser User user){
 
         Slice<Cookie> cookieSlice = cookieService.getRandomCookies(pageable);
-        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(CookieResponse::of);
+        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(c -> CookieResponse.of(c, user));
 
         SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieResponseSlice);
 
@@ -50,11 +54,11 @@ public class CookieController {
 
     @GetMapping("/{cookieId}")
     public ResponseEntity<ApiResponse<CookieResponse>> getCookieById(
-            @PathVariable Long cookieId){
+            @PathVariable Long cookieId, @CurrentUser User user){
 
         Cookie cookie = cookieService.getCookieById(cookieId);
 
-        CookieResponse data = CookieResponse.of(cookie);
+        CookieResponse data = CookieResponse.of(cookie, user);
 
         ApiResponse response = ApiResponse.builder()
                 .message("쿠키 단건 조회 성공")
@@ -65,13 +69,29 @@ public class CookieController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> searchCookies(@CurrentUser User user, @RequestParam(value = "query") String query,
+                                                                                    @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+
+        SliceResponse<CookieResponse> response = new SliceResponse<>(cookieService.searchCookiesWith(query, pageable));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("쿠키 검색 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
+
     @GetMapping("/user/{userId}")
     public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getCookiesOfUser(
             @PathVariable Long userId,
             @PageableDefault(size = COOKIE_SLICE_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
 
+        User user = userSimpleService.getUserById(userId);
         Slice<Cookie> cookieSlice = cookieService.getCookiesOfUser(pageable, userId);
-        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(CookieResponse::of);
+        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(c -> CookieResponse.of(c, user));
 
         SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieResponseSlice);
 

--- a/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
+++ b/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
@@ -38,10 +38,9 @@ public class CookieController {
     public ResponseEntity<ApiResponse<SliceResponse<CookieResponse>>> getRandomCookies(
             @PageableDefault(size = COOKIE_SLICE_SIZE) Pageable pageable, @CurrentUser User user){
 
-        Slice<Cookie> cookieSlice = cookieService.getRandomCookies(pageable);
-        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(c -> CookieResponse.of(c, user));
+        Slice<CookieResponse> cookieSlice = cookieService.getRandomCookies(pageable);
 
-        SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieResponseSlice);
+        SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieSlice);
 
         ApiResponse response = ApiResponse.builder()
                 .message("쿠키 조회 성공")
@@ -56,9 +55,7 @@ public class CookieController {
     public ResponseEntity<ApiResponse<CookieResponse>> getCookieById(
             @PathVariable Long cookieId, @CurrentUser User user){
 
-        Cookie cookie = cookieService.getCookieById(cookieId);
-
-        CookieResponse data = CookieResponse.of(cookie, user);
+        CookieResponse data = cookieService.getCookieById(cookieId);
 
         ApiResponse response = ApiResponse.builder()
                 .message("쿠키 단건 조회 성공")
@@ -89,9 +86,7 @@ public class CookieController {
             @PathVariable Long userId,
             @PageableDefault(size = COOKIE_SLICE_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
 
-        User user = userSimpleService.getUserById(userId);
-        Slice<Cookie> cookieSlice = cookieService.getCookiesOfUser(pageable, userId);
-        Slice<CookieResponse> cookieResponseSlice = cookieSlice.map(c -> CookieResponse.of(c, user));
+        Slice<CookieResponse> cookieResponseSlice = cookieService.getCookiesOfUser(pageable, userId);
 
         SliceResponse<CookieResponse> sliceResponse = new SliceResponse<>(cookieResponseSlice);
 

--- a/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
+++ b/src/main/java/com/swef/cookcode/cookie/controller/CookieController.java
@@ -3,13 +3,11 @@ package com.swef.cookcode.cookie.controller;
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.SliceResponse;
 import com.swef.cookcode.common.entity.CurrentUser;
-import com.swef.cookcode.cookie.domain.Cookie;
 import com.swef.cookcode.cookie.dto.CookieCreateRequest;
 import com.swef.cookcode.cookie.dto.CookiePatchRequest;
 import com.swef.cookcode.cookie.dto.CookieResponse;
 import com.swef.cookcode.cookie.service.CookieService;
 import com.swef.cookcode.user.domain.User;
-import com.swef.cookcode.user.service.UserSimpleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,8 +27,6 @@ import static org.springframework.http.HttpStatus.OK;
 public class CookieController {
 
     private final CookieService cookieService;
-
-    private final UserSimpleService userSimpleService;
 
     private final int COOKIE_SLICE_SIZE = 5;
 

--- a/src/main/java/com/swef/cookcode/cookie/dto/CookieDto.java
+++ b/src/main/java/com/swef/cookcode/cookie/dto/CookieDto.java
@@ -1,0 +1,25 @@
+package com.swef.cookcode.cookie.dto;
+
+import java.time.LocalDateTime;
+
+public interface CookieDto {
+    Long getCookieId();
+
+    String getTitle();
+
+    String getDescription();
+
+    String getVideoUrl();
+
+    Long getUserId();
+
+    String getProfileImage();
+
+    String getNickname();
+
+    Long getRecipeId();
+
+    LocalDateTime getCreatedAt();
+
+    LocalDateTime getUpdatedAt();
+}

--- a/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
+++ b/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
@@ -30,7 +30,7 @@ public class CookieResponse {
         this.user = UserSimpleResponse.from(cookie.getUser());
     }
 
-    public static CookieResponse of(Cookie cookie, User user){
+    public static CookieResponse of(Cookie cookie){
         return new CookieResponse(cookie);
     }
 }

--- a/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
+++ b/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
@@ -1,14 +1,20 @@
 package com.swef.cookcode.cookie.dto;
 
 import com.swef.cookcode.cookie.domain.Cookie;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class CookieResponse {
 
     private final Long id;
+
+    private final UserSimpleResponse user;
 
     private final String title;
 
@@ -16,7 +22,15 @@ public class CookieResponse {
 
     private final String videoUrl;
 
-    public static CookieResponse of(Cookie cookie){
-        return new CookieResponse(cookie.getId(), cookie.getTitle(), cookie.getDescription(), cookie.getVideoUrl());
+    public CookieResponse(Cookie cookie) {
+        this.id = cookie.getId();
+        this.title = cookie.getTitle();
+        this.desc = cookie.getDescription();
+        this.videoUrl = cookie.getVideoUrl();
+        this.user = UserSimpleResponse.from(cookie.getUser());
+    }
+
+    public static CookieResponse of(Cookie cookie, User user){
+        return new CookieResponse(cookie);
     }
 }

--- a/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
+++ b/src/main/java/com/swef/cookcode/cookie/dto/CookieResponse.java
@@ -1,8 +1,11 @@
 package com.swef.cookcode.cookie.dto;
 
+import static java.util.Objects.nonNull;
+
 import com.swef.cookcode.cookie.domain.Cookie;
 import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.dto.response.UserSimpleResponse;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,15 +25,40 @@ public class CookieResponse {
 
     private final String videoUrl;
 
+    private final Long recipeId;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
     public CookieResponse(Cookie cookie) {
         this.id = cookie.getId();
         this.title = cookie.getTitle();
         this.desc = cookie.getDescription();
         this.videoUrl = cookie.getVideoUrl();
         this.user = UserSimpleResponse.from(cookie.getUser());
+        this.createdAt = cookie.getCreatedAt();
+        this.updatedAt = cookie.getUpdatedAt();
+        this.recipeId = nonNull(cookie.getRecipe()) ? cookie.getRecipe().getId() : null;
     }
 
     public static CookieResponse of(Cookie cookie){
         return new CookieResponse(cookie);
+    }
+
+    public static CookieResponse of(CookieDto dto) {
+        return CookieResponse.builder()
+                .id(dto.getCookieId())
+                .title(dto.getTitle())
+                .desc(dto.getDescription())
+                .videoUrl(dto.getVideoUrl())
+                .createdAt(dto.getCreatedAt())
+                .updatedAt(dto.getUpdatedAt())
+                .recipeId(dto.getRecipeId())
+                .user(UserSimpleResponse.builder()
+                        .userId(dto.getUserId())
+                        .nickname(dto.getNickname())
+                        .profileImage(dto.getProfileImage()).build())
+                .build();
     }
 }

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieCustomRepository.java
@@ -1,0 +1,9 @@
+package com.swef.cookcode.cookie.repository;
+
+import com.swef.cookcode.cookie.dto.CookieResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CookieCustomRepository {
+    Slice<CookieResponse> searchCookies(String query, Pageable pageable);
+}

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
@@ -1,15 +1,16 @@
 package com.swef.cookcode.cookie.repository;
 
 import com.swef.cookcode.cookie.domain.Cookie;
+import com.swef.cookcode.cookie.dto.CookieDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CookieRepository extends JpaRepository<Cookie, Long>, CookieCustomRepository {
-    @Query(value = "SELECT c.* FROM cookie as c join users u on c.user_id = u.user_id ORDER BY RAND()", nativeQuery = true)
-    Slice<Cookie> findRandomCookies(Pageable pageable);
+    @Query(value = "SELECT c.cookie_id as cookieId, recipe_id as recipeId, c.title, c.description, c.video_url as videoUrl, c.created_at as createdAt, c.updated_at as updatedAt, u.user_id as userId, u.profile_image as profileImage, u.nickname  FROM cookie as c join users u on c.user_id = u.user_id ORDER BY RAND()", nativeQuery = true)
+    Slice<CookieDto> findRandomCookies(Pageable pageable);
 
-    @Query(value = "SELECT c FROM Cookie c WHERE c.user.id = :userId")
+    @Query(value = "SELECT c FROM Cookie c join fetch c.user WHERE c.user.id = :userId")
     Slice<Cookie> findByUserId(Pageable pageable, Long userId);
 }

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface CookieRepository extends JpaRepository<Cookie, Long> {
+public interface CookieRepository extends JpaRepository<Cookie, Long>, CookieCustomRepository {
     @Query(value = "SELECT * FROM cookie ORDER BY RAND()", nativeQuery = true)
     Slice<Cookie> findRandomCookies(Pageable pageable);
 

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CookieRepository extends JpaRepository<Cookie, Long>, CookieCustomRepository {
-    @Query(value = "SELECT * FROM cookie ORDER BY RAND()", nativeQuery = true)
+    @Query(value = "SELECT c.* FROM cookie as c join users u on c.user_id = u.user_id ORDER BY RAND()", nativeQuery = true)
     Slice<Cookie> findRandomCookies(Pageable pageable);
 
     @Query(value = "SELECT c FROM Cookie c WHERE c.user.id = :userId")

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.swef.cookcode.cookie.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.swef.cookcode.common.Util;
+import com.swef.cookcode.cookie.domain.QCookie;
+import com.swef.cookcode.cookie.dto.CookieResponse;
+import com.swef.cookcode.user.domain.QUser;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class CookieRepositoryImpl implements CookieCustomRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QCookie cookie = QCookie.cookie;
+
+    @Override
+    public Slice<CookieResponse> searchCookies(String query, Pageable pageable) {
+        List<CookieResponse> responses = queryFactory.select(Projections.constructor(CookieResponse.class,
+                cookie))
+                .from(cookie)
+                .join(cookie.user)
+                .fetchJoin()
+                .where(cookieSearchContains(query))
+                .fetch();
+
+        return new SliceImpl<>(responses, pageable, Util.hasNextInSlice(responses, pageable));
+    }
+
+    private BooleanExpression cookieSearchContains(String query) {
+        return cookie.title.containsIgnoreCase(query)
+                .or(cookie.description.containsIgnoreCase(query))
+                .or(cookie.user.nickname.containsIgnoreCase(query));
+    }
+}

--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepositoryImpl.java
@@ -1,12 +1,12 @@
 package com.swef.cookcode.cookie.repository;
 
+import static com.swef.cookcode.cookie.domain.QCookie.cookie;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.swef.cookcode.common.Util;
-import com.swef.cookcode.cookie.domain.QCookie;
 import com.swef.cookcode.cookie.dto.CookieResponse;
-import com.swef.cookcode.user.domain.QUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -17,8 +17,6 @@ import org.springframework.data.domain.SliceImpl;
 public class CookieRepositoryImpl implements CookieCustomRepository{
 
     private final JPAQueryFactory queryFactory;
-
-    private final QCookie cookie = QCookie.cookie;
 
     @Override
     public Slice<CookieResponse> searchCookies(String query, Pageable pageable) {

--- a/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
+++ b/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
@@ -5,9 +5,9 @@ import com.swef.cookcode.common.util.S3Util;
 import com.swef.cookcode.cookie.domain.Cookie;
 import com.swef.cookcode.cookie.dto.CookieCreateRequest;
 import com.swef.cookcode.cookie.dto.CookiePatchRequest;
+import com.swef.cookcode.cookie.dto.CookieResponse;
 import com.swef.cookcode.cookie.repository.CookieRepository;
 import com.swef.cookcode.recipe.domain.Recipe;
-import com.swef.cookcode.recipe.repository.RecipeRepository;
 import com.swef.cookcode.recipe.service.RecipeService;
 import com.swef.cookcode.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +15,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
-import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.common.ErrorCode;
 
 import static com.swef.cookcode.common.ErrorCode.COOKIE_NOT_FOUND;
-import static java.util.Objects.isNull;
 
 @Service
 @RequiredArgsConstructor
@@ -71,6 +69,11 @@ public class CookieService {
     @Transactional
     public void deleteCookie(Long cookieId) {
         cookieRepository.deleteById(cookieId);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<CookieResponse> searchCookiesWith(String query, Pageable pageable) {
+        return cookieRepository.searchCookies(query, pageable);
     }
 
 }

--- a/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
+++ b/src/main/java/com/swef/cookcode/cookie/service/CookieService.java
@@ -31,19 +31,20 @@ public class CookieService {
 
 
     @Transactional(readOnly = true)
-    public Slice<Cookie> getRandomCookies(Pageable pageable) {
-        return cookieRepository.findRandomCookies(pageable);
+    public Slice<CookieResponse> getRandomCookies(Pageable pageable) {
+        return cookieRepository.findRandomCookies(pageable).map(CookieResponse::of);
     }
 
     @Transactional(readOnly = true)
-    public Cookie getCookieById(Long cookieId) {
-        return cookieRepository.findById(cookieId)
+    public CookieResponse getCookieById(Long cookieId) {
+        Cookie cookie = cookieRepository.findById(cookieId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.COOKIE_NOT_FOUND));
+        return CookieResponse.of(cookie);
     }
 
     @Transactional(readOnly = true)
-    public Slice<Cookie> getCookiesOfUser(Pageable pageable, Long userId) {
-        return cookieRepository.findByUserId(pageable, userId);
+    public Slice<CookieResponse> getCookiesOfUser(Pageable pageable, Long userId) {
+        return cookieRepository.findByUserId(pageable, userId).map(CookieResponse::of);
     }
 
     @Transactional

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -2,6 +2,7 @@ package com.swef.cookcode.recipe.controller;
 
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.PageResponse;
+import com.swef.cookcode.common.SliceResponse;
 import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.recipe.domain.Recipe;
@@ -55,6 +56,23 @@ public class RecipeController {
         return ResponseEntity.ok()
                 .body(apiResponse);
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> searchRecipes(@CurrentUser User user, @RequestParam(value = "query") String query,
+                                                                                   @RequestParam(value = "cookable", required = false) Boolean isCookable,
+                                                                                   @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+
+        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.getRecipeResponsesBySearch(user, query, isCookable, pageable));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("레시피 다건 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok().body(apiResponse);
+
+    }
+
 
     @PostMapping("/files/{directory}")
     public ResponseEntity<ApiResponse<UrlResponse>> uploadRecipePhotos(@RequestPart(value = "stepFiles") List<MultipartFile> files, @PathVariable(value = "directory") String directory) {

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -109,7 +109,7 @@ public class RecipeController {
                                                                                @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
                                                                                Pageable pageable)
     {
-        PageResponse<RecipeResponse> response = new PageResponse<>(recipeService.getRecipeResponses(user, isCookable, month, pageable));
+        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.getRecipeResponses(user, isCookable, month, pageable));
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 다건 조회 성공")
                 .status(HttpStatus.OK.value())

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -5,7 +5,6 @@ import com.swef.cookcode.common.PageResponse;
 import com.swef.cookcode.common.SliceResponse;
 import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.entity.CurrentUser;
-import com.swef.cookcode.recipe.domain.Recipe;
 import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeUpdateRequest;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
@@ -63,9 +62,9 @@ public class RecipeController {
                                                                                    @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
 
-        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.getRecipeResponsesBySearch(user, query, isCookable, pageable));
+        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.searchRecipesWith(user, query, isCookable, pageable));
         ApiResponse apiResponse = ApiResponse.builder()
-                .message("레시피 다건 조회 성공")
+                .message("레시피 검색 성공")
                 .status(HttpStatus.OK.value())
                 .data(response)
                 .build();

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
@@ -46,9 +46,9 @@ public class RecipeResponse {
 
     private String thumbnail;
 
-    public RecipeResponse(Recipe recipe, User user, Boolean isCookable) {
+    public RecipeResponse(Recipe recipe, Boolean isCookable) {
         this.recipeId = recipe.getId();
-        this.user = UserSimpleResponse.from(user);
+        this.user = UserSimpleResponse.from(recipe.getAuthor());
         this.title = recipe.getTitle();
         this.description = recipe.getDescription();
         this.ingredients = convert(recipe.getNecessaryIngredients());
@@ -90,9 +90,5 @@ public class RecipeResponse {
 
     private static List<IngredSimpleResponse> convert(List<RecipeIngred> ingreds) {
         return ingreds.stream().map(i -> IngredSimpleResponse.from(i.getIngredient())).toList();
-    }
-
-    public void setIsCookable(Boolean isCookable) {
-        this.isCookable = isCookable;
     }
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface RecipeCustomRepository {
-    Page<RecipeResponse> findRecipes(Long userId, Boolean isCookable, Pageable pageable);
+    Slice<RecipeResponse> findRecipes(Long userId, Boolean isCookable, Pageable pageable);
 
     Slice<RecipeResponse> searchRecipes(Long userId, String query, Boolean isCookable, Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
@@ -3,7 +3,10 @@ package com.swef.cookcode.recipe.repository;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface RecipeCustomRepository {
     Page<RecipeResponse> findRecipes(Long userId, Boolean isCookable, Pageable pageable);
+
+    Slice<RecipeResponse> searchRecipes(Long userId, String query, Boolean isCookable, Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepository.java
@@ -20,4 +20,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long>, RecipeCus
 
     boolean existsById(Long recipeId);
 
+
+
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
@@ -32,7 +32,7 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
     private final QUser user = QUser.user;
 
     @Override
-    public Page<RecipeResponse> findRecipes(Long fridgeId, Boolean isCookable, Pageable pageable) {
+    public Slice<RecipeResponse> findRecipes(Long fridgeId, Boolean isCookable, Pageable pageable) {
 
         JPAQuery<RecipeResponse> query = queryFactory.select(Projections.constructor(RecipeResponse.class, recipe, user, isCookableExpression().as("isCookable")))
                 .from(recipe)
@@ -46,9 +46,9 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
         }
 
         List<RecipeResponse> result = query.orderBy(recipe.createdAt.desc()).offset(pageable.getOffset()).limit(
-                pageable.getPageSize()).fetch();
+                pageable.getPageSize()+1).fetch();
 
-        return new PageImpl<>(result, pageable, result.size());
+        return new SliceImpl<>(result, pageable, hasNextInSlice(result, pageable));
     }
 
     @Override

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -163,15 +163,15 @@ public class RecipeService {
     }
 
     @Transactional(readOnly = true)
-    public Page<RecipeResponse> getRecipeResponses(User user, Boolean isCookable, Integer month, Pageable pageable) {
+    public Slice<RecipeResponse> getRecipeResponses(User user, Boolean isCookable, Integer month, Pageable pageable) {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
-        Page<RecipeResponse> responses = recipeRepository.findRecipes(fridgeId, isCookable, pageable);
+        Slice<RecipeResponse> responses = recipeRepository.findRecipes(fridgeId, isCookable, pageable);
         return responses;
     }
 
     public Slice<RecipeResponse> getRecipeResponsesBySearch(User user, String query, Boolean isCookable, Pageable pageable) {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
-        Slice<RecipeResponse> responses = recipeRepository.searchRecipes(user.getId(), query, isCookable, pageable);
+        Slice<RecipeResponse> responses = recipeRepository.searchRecipes(fridgeId, query, isCookable, pageable);
         return responses;
     }
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -169,7 +168,7 @@ public class RecipeService {
         return responses;
     }
 
-    public Slice<RecipeResponse> getRecipeResponsesBySearch(User user, String query, Boolean isCookable, Pageable pageable) {
+    public Slice<RecipeResponse> searchRecipesWith(User user, String query, Boolean isCookable, Pageable pageable) {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
         Slice<RecipeResponse> responses = recipeRepository.searchRecipes(fridgeId, query, isCookable, pageable);
         return responses;

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -165,6 +166,12 @@ public class RecipeService {
     public Page<RecipeResponse> getRecipeResponses(User user, Boolean isCookable, Integer month, Pageable pageable) {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
         Page<RecipeResponse> responses = recipeRepository.findRecipes(fridgeId, isCookable, pageable);
+        return responses;
+    }
+
+    public Slice<RecipeResponse> getRecipeResponsesBySearch(User user, String query, Boolean isCookable, Pageable pageable) {
+        Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
+        Slice<RecipeResponse> responses = recipeRepository.searchRecipes(user.getId(), query, isCookable, pageable);
         return responses;
     }
 }

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -4,6 +4,8 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.PageResponse;
+import com.swef.cookcode.common.SliceResponse;
 import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.common.jwt.JwtAuthenticationToken;
 import com.swef.cookcode.common.jwt.JwtPrincipal;
@@ -15,6 +17,7 @@ import com.swef.cookcode.user.dto.response.SignInResponse;
 import com.swef.cookcode.user.dto.response.SignUpResponse;
 import com.swef.cookcode.user.dto.response.UniqueCheckResponse;
 import com.swef.cookcode.user.dto.response.UserDetailResponse;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import com.swef.cookcode.user.service.UserService;
 import com.swef.cookcode.user.service.UserSimpleService;
 import jakarta.validation.Valid;
@@ -24,6 +27,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -121,6 +128,21 @@ public class AccountController {
                 .message("계정 삭제 성공")
                 .status(OK.value())
                 .data(UserDetailResponse.from(returnedUser))
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<SliceResponse<UserDetailResponse>>> searchUsers(@CurrentUser User user,
+                                                                                      @RequestParam(value = "nickname") String nickname,
+                                                                                      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                                          Pageable pageable) {
+        Slice<User> users = userService.searchUsersWith(nickname, pageable);
+        SliceResponse<UserDetailResponse> response = new SliceResponse<>(users.map(UserDetailResponse::from));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("유저 검색 성공")
+                .status(OK.value())
+                .data(response)
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -3,7 +3,10 @@ package com.swef.cookcode.user.repository;
 import com.swef.cookcode.user.domain.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
         Optional<User> findByIdAndIsQuit(@Param("userId") Long userId, @Param("isQuit") Boolean isQuit);
@@ -17,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNicknameAndIsQuit(@Param("nickname") String nickname, @Param("isQuit") Boolean isQuit);
 
     boolean existsByIdAndIsQuit(@Param("userId") Long userId, @Param("isQuit") Boolean isQuit);
+
+    @Query(value = "select u from User u where u.isQuit = false and u.authority = 'USER' and u.nickname like %:searchQuery%")
+    Slice<User> findByNicknameContaining(@Param("searchQuery") String searchQuery, Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -13,6 +13,8 @@ import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.dto.request.UserSignUpRequest;
 import com.swef.cookcode.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,6 +69,11 @@ public class UserService {
         user.quit();
         userRepository.save(user);
         return user;
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<User> searchUsersWith(String searchQuery, Pageable pageable) {
+        return userRepository.findByNicknameContaining(searchQuery, pageable);
     }
 
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/search -> main

## 변경 사항
* 기존 레시피 검색 시 cookable을 판단하는 쿼리를 다른 방식으로 변경했습니다.
  * 이전에는 is_necessary 필드가 true인 recipeIngred들에 대해서만 join을 진행하였는데, 보조재료에서도 검색이 되어야 한다는 필요성을 깨닫고, 관련된 모든 recipeIngred를 join 후, case when을 사용하여 cookable을 판단할 때만 is_necessary를 고려했습니다.
* 사용자 검색은 필드가 닉네임밖에 없고 간단하여 기존 jpql 그대로 구현하였습니다.
* 쿠키 검색을 위해 cookieCustomRepository와 구현체를 생성하였습니다.
* dto 변환을 presentation layer에서 하는 것을 service layer에서 수행하도록 변경하였습니다.

## 집중했으면 좋은 점
* 쿠키 조회를 위한 response dto를 생성하였는데, native query가 entity에 fetch join을 하지 않고 있어 n+1문제가 발생하는 것을 발견하였습니다.

### 형변환을 service layer에 위임한 이유
1. 쿠키를 랜덤으로 5개 추출해 올 때, cookie entity의 user 필드는 proxy를 갖게됩니다. 이전 코드는 dto 형 변환을 presentation layer(controller layer)에서 하고 있는데, 이렇게 되면 service layer에서 transaction이 종료된 이후 연관된 엔티티의 필드를 부르게 되어서 LazyInitializationException이 발생하게 됩니다. 따라서 다음과 같은 방법으로 해결하였습니다.

### 문제 해결 방법
1. controller layer에서 entity 드러내지 말기
* service들은 cookie가 아닌 cookie response를 반환하도록 만들어서 지연 로딩이 영속성컨텍스트 내에서 정상적으로 일어나도록 했습니다.
2. cookie 가져올 때 user 정보를 가져와서 n+1 문제 방지
* 다만, 이렇게 되면 cookie를 가져올 때 마다 user를 조회하는 쿼리가 나가게 되므로 fetch join을 진행했습니다.
* 단건 조회에서는 fetch join 사용
* native query에서는 fetch join 하는 방법을 못찾겠어서, interface를 통한 projection을 활용했습니다. 

## 테스트 결과
### 쿠키 조회
<img width="1089" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/05e1bf19-f4fb-444a-8a04-a17b233c5450">

### 검색
<img width="1089" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/6c9d7ebf-cec4-459c-ba23-a3a7ef8f8cb4">
