### PR TITLE
레시피 댓글 구현

### DIFF
--- a/src/main/java/com/swef/cookcode/common/ErrorCode.java
+++ b/src/main/java/com/swef/cookcode/common/ErrorCode.java
@@ -67,10 +67,12 @@ public enum ErrorCode {
   /*
   Recipe Domain
    */
-  RECIPE_NOT_FOUND(400, "I001", "존재하지 않는 레시피입니다."),
+  RECIPE_NOT_FOUND(400, "R001", "존재하지 않는 레시피입니다."),
+  RECIPE_COMMENT_NOT_FOUND(400, "R002", "존재하지 않는 레시피 댓글입니다."),
+  RECIPE_COMMENT_USER_MISSMATCH(400,"R003", "해당 유저의 댓글이 아닙니다."),
 
   /*
-  Recipe Domain
+  Cookie Domain
    */
   COOKIE_NOT_FOUND(400, "K001", "존재하지 않는 쿠키입니다."),
   COOKIE_COMMENT_NOT_FOUND(400,"K002", "존재하지 않는 쿠키 댓글입니다."),

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -85,6 +85,17 @@ public class RecipeController {
         return ResponseEntity.ok(apiResponse);
     }
 
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse> deleteComment(@CurrentUser User user, @PathVariable(value = "commentId") Long commentId) {
+        recipeService.deleteCommentOfRecipe(user, commentId);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("레시피 댓글 삭제 성공")
+                .status(HttpStatus.OK.value())
+                .build();
+        return ResponseEntity.ok(apiResponse);
+
+    }
+
 
     @PostMapping("/files/{directory}")
     public ResponseEntity<ApiResponse<UrlResponse>> uploadRecipePhotos(@RequestPart(value = "stepFiles") List<MultipartFile> files, @PathVariable(value = "directory") String directory) {

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -100,7 +100,7 @@ public class RecipeController {
     public ResponseEntity<ApiResponse<SliceResponse<RecipeCommentResponse>>> getCommentsOfRecipe(@PathVariable(value = "recipeId") Long recipeId,
                                                                                                  @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
                                                                                                  Pageable pageable) {
-        SliceResponse<RecipeCommentResponse> response = new SliceResponse<>(recipeService.getCommentsOfRecipe(pageable));
+        SliceResponse<RecipeCommentResponse> response = new SliceResponse<>(recipeService.getCommentsOfRecipe(recipeId, pageable));
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 댓글 다건 조회 성공")
                 .status(HttpStatus.OK.value())

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -76,10 +76,11 @@ public class RecipeController {
     @PostMapping("/{recipeId}/comments")
     public ResponseEntity<ApiResponse<RecipeCommentResponse>> commentRecipe(@CurrentUser User user, @PathVariable(value = "recipeId") Long recipeId, @RequestBody
                                                                             RecipeCommentCreateRequest request) {
+        RecipeCommentResponse response = recipeService.createComment(user, recipeId, request);
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 댓글 작성 성공")
                 .status(HttpStatus.OK.value())
-                .data(null)
+                .data(response)
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -5,8 +5,10 @@ import com.swef.cookcode.common.PageResponse;
 import com.swef.cookcode.common.SliceResponse;
 import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.recipe.dto.request.RecipeCommentCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeUpdateRequest;
+import com.swef.cookcode.recipe.dto.response.RecipeCommentResponse;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
 import com.swef.cookcode.common.UrlResponse;
 import com.swef.cookcode.recipe.service.RecipeService;
@@ -70,6 +72,17 @@ public class RecipeController {
                 .build();
         return ResponseEntity.ok().body(apiResponse);
 
+    }
+
+    @PostMapping("/{recipeId}/comments")
+    public ResponseEntity<ApiResponse<RecipeCommentResponse>> commentRecipe(@CurrentUser User user, @PathVariable(value = "recipeId") Long recipeId, @RequestBody
+                                                                            RecipeCommentCreateRequest request) {
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("레시피 댓글 작성 성공")
+                .status(HttpStatus.OK.value())
+                .data(null)
+                .build();
+        return ResponseEntity.ok(apiResponse);
     }
 
 

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -96,6 +96,20 @@ public class RecipeController {
 
     }
 
+    @GetMapping("/{recipeId}/comments")
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeCommentResponse>>> getCommentsOfRecipe(@PathVariable(value = "recipeId") Long recipeId,
+                                                                                                 @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                                                 Pageable pageable) {
+        SliceResponse<RecipeCommentResponse> response = new SliceResponse<>(recipeService.getCommentsOfRecipe(pageable));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("레시피 댓글 다건 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+
+    }
+
 
     @PostMapping("/files/{directory}")
     public ResponseEntity<ApiResponse<UrlResponse>> uploadRecipePhotos(@RequestPart(value = "stepFiles") List<MultipartFile> files, @PathVariable(value = "directory") String directory) {
@@ -124,7 +138,7 @@ public class RecipeController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<RecipeResponse>>> getRecipe(@CurrentUser User user,
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipe(@CurrentUser User user,
                                                                                @RequestParam(value = "cookable", required = false) Boolean isCookable,
                                                                                @RequestParam(value = "month", required = false) Integer month,
                                                                                @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -54,8 +54,7 @@ public class RecipeController {
                 .data(response)
                 .build();
 
-        return ResponseEntity.ok()
-                .body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
     }
 
     @GetMapping("/search")
@@ -70,7 +69,7 @@ public class RecipeController {
                 .status(HttpStatus.OK.value())
                 .data(response)
                 .build();
-        return ResponseEntity.ok().body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
 
     }
 
@@ -94,8 +93,7 @@ public class RecipeController {
                 .status(HttpStatus.OK.value())
                 .data(response)
                 .build();
-        return ResponseEntity.ok()
-                .body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
     }
 
     @PatchMapping("/{recipeId}")
@@ -110,8 +108,7 @@ public class RecipeController {
                 .data(response)
                 .build();
 
-        return ResponseEntity.ok()
-                .body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
     }
 
     @GetMapping
@@ -127,7 +124,7 @@ public class RecipeController {
                 .status(HttpStatus.OK.value())
                 .data(response)
                 .build();
-        return ResponseEntity.ok().body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
     }
 
     @GetMapping("/{recipeId}")
@@ -139,8 +136,7 @@ public class RecipeController {
                 .data(recipeService.getRecipeResponseById(recipeId))
                 .build();
 
-        return ResponseEntity.ok()
-                .body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
     }
 
     @DeleteMapping("/{recipeId}")
@@ -153,8 +149,7 @@ public class RecipeController {
                 .status(HttpStatus.OK.value())
                 .build();
 
-        return ResponseEntity.ok()
-                .body(apiResponse);
+        return ResponseEntity.ok(apiResponse);
     }
 
 }

--- a/src/main/java/com/swef/cookcode/recipe/domain/RecipeComment.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/RecipeComment.java
@@ -12,6 +12,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,5 +40,11 @@ public class RecipeComment extends BaseEntity {
 
     @Column(nullable = false, length = MAX_COMMENT_LENGTH)
     private String comment;
+
+    public RecipeComment(Recipe recipe, User user, String comment) {
+        this.recipe = recipe;
+        this.user = user;
+        this.comment = comment;
+    }
 
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCommentCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCommentCreateRequest.java
@@ -1,7 +1,9 @@
 package com.swef.cookcode.recipe.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
 
+@Getter
 public class RecipeCommentCreateRequest {
     @NotBlank
     private String comment;

--- a/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCommentCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/request/RecipeCommentCreateRequest.java
@@ -1,0 +1,8 @@
+package com.swef.cookcode.recipe.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class RecipeCommentCreateRequest {
+    @NotBlank
+    private String comment;
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeCommentResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeCommentResponse.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.recipe.dto.response;
 
+import com.swef.cookcode.recipe.domain.RecipeComment;
 import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -14,4 +15,13 @@ public class RecipeCommentResponse {
     private final UserSimpleResponse user;
 
     private final String comment;
+
+    public static RecipeCommentResponse from(RecipeComment comment) {
+        return RecipeCommentResponse.builder()
+                .commentId(comment.getId())
+                .recipeId(comment.getRecipe().getId())
+                .user(UserSimpleResponse.from(comment.getUser()))
+                .comment(comment.getComment())
+                .build();
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeCommentResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeCommentResponse.java
@@ -1,0 +1,17 @@
+package com.swef.cookcode.recipe.dto.response;
+
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@RequiredArgsConstructor
+public class RecipeCommentResponse {
+    private final Long commentId;
+
+    private final Long recipeId;
+
+    private final UserSimpleResponse user;
+
+    private final String comment;
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
@@ -46,7 +46,7 @@ public class RecipeResponse {
 
     private String thumbnail;
 
-    public RecipeResponse(Recipe recipe, Boolean isCookable) {
+    public RecipeResponse(Recipe recipe, Boolean isCookable, Long commentCount) {
         this.recipeId = recipe.getId();
         this.user = UserSimpleResponse.from(recipe.getAuthor());
         this.title = recipe.getTitle();
@@ -57,6 +57,7 @@ public class RecipeResponse {
         this.updatedAt = recipe.getUpdatedAt();
         this.isCookable = isCookable;
         this.thumbnail = recipe.getThumbnail();
+        this.commentCount = commentCount;
     }
 
     public static RecipeResponse from(Recipe recipe) {

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCommentRepository.java
@@ -1,0 +1,7 @@
+package com.swef.cookcode.recipe.repository;
+
+import com.swef.cookcode.recipe.domain.RecipeComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Long> {
+}

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCommentRepository.java
@@ -1,7 +1,13 @@
 package com.swef.cookcode.recipe.repository;
 
 import com.swef.cookcode.recipe.domain.RecipeComment;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Long> {
+    @Query("select rc from RecipeComment rc join fetch rc.user where rc.recipe.id = :recipeId")
+    Slice<RecipeComment> findRecipeComments(@Param("recipeId") Long recipeId, Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -192,4 +192,8 @@ public class RecipeService {
         if (!Objects.equals(user.getId(), comment.getUser().getId())) throw new PermissionDeniedException(ErrorCode.RECIPE_COMMENT_USER_MISSMATCH);
         recipeCommentRepository.delete(comment);
     }
+
+    public Slice<RecipeCommentResponse> getCommentsOfRecipe(Pageable pageable) {
+        return null;
+    }
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -193,7 +193,8 @@ public class RecipeService {
         recipeCommentRepository.delete(comment);
     }
 
-    public Slice<RecipeCommentResponse> getCommentsOfRecipe(Pageable pageable) {
-        return null;
+    public Slice<RecipeCommentResponse> getCommentsOfRecipe(Long recipeId, Pageable pageable) {
+        if (recipeRepository.findById(recipeId).isEmpty()) throw new NotFoundException(ErrorCode.RECIPE_NOT_FOUND);
+        return recipeCommentRepository.findRecipeComments(recipeId, pageable).map(RecipeCommentResponse::from);
     }
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -12,7 +12,6 @@ import com.swef.cookcode.fridge.service.IngredientSimpleService;
 import com.swef.cookcode.recipe.domain.Recipe;
 import com.swef.cookcode.recipe.domain.RecipeComment;
 import com.swef.cookcode.recipe.domain.RecipeIngred;
-import com.swef.cookcode.recipe.domain.RecipeLike;
 import com.swef.cookcode.recipe.domain.StepPhoto;
 import com.swef.cookcode.recipe.domain.StepVideo;
 import com.swef.cookcode.recipe.dto.request.RecipeCommentCreateRequest;
@@ -169,15 +168,28 @@ public class RecipeService {
         return responses;
     }
 
+    @Transactional(readOnly = true)
     public Slice<RecipeResponse> searchRecipesWith(User user, String query, Boolean isCookable, Pageable pageable) {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
         Slice<RecipeResponse> responses = recipeRepository.searchRecipes(fridgeId, query, isCookable, pageable);
         return responses;
     }
 
+    @Transactional
     public RecipeCommentResponse createComment(User user, Long recipeId, RecipeCommentCreateRequest request) {
         Recipe recipe = getRecipeById(recipeId);
         RecipeComment comment = new RecipeComment(recipe, user, request.getComment());
         return RecipeCommentResponse.from(recipeCommentRepository.save(comment));
+    }
+
+    RecipeComment getRecipeCommentById(Long commentId) {
+        return recipeCommentRepository.findById(commentId).orElseThrow(() -> new NotFoundException(ErrorCode.RECIPE_COMMENT_NOT_FOUND));
+    }
+
+    @Transactional
+    public void deleteCommentOfRecipe(User user, Long commentId) {
+        RecipeComment comment = getRecipeCommentById(commentId);
+        if (!Objects.equals(user.getId(), comment.getUser().getId())) throw new PermissionDeniedException(ErrorCode.RECIPE_COMMENT_USER_MISSMATCH);
+        recipeCommentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -10,12 +10,17 @@ import com.swef.cookcode.fridge.domain.Ingredient;
 import com.swef.cookcode.fridge.service.FridgeService;
 import com.swef.cookcode.fridge.service.IngredientSimpleService;
 import com.swef.cookcode.recipe.domain.Recipe;
+import com.swef.cookcode.recipe.domain.RecipeComment;
 import com.swef.cookcode.recipe.domain.RecipeIngred;
+import com.swef.cookcode.recipe.domain.RecipeLike;
 import com.swef.cookcode.recipe.domain.StepPhoto;
 import com.swef.cookcode.recipe.domain.StepVideo;
+import com.swef.cookcode.recipe.dto.request.RecipeCommentCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeCreateRequest;
 import com.swef.cookcode.recipe.dto.request.RecipeUpdateRequest;
+import com.swef.cookcode.recipe.dto.response.RecipeCommentResponse;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
+import com.swef.cookcode.recipe.repository.RecipeCommentRepository;
 import com.swef.cookcode.recipe.repository.RecipeIngredRepository;
 import com.swef.cookcode.recipe.repository.RecipeRepository;
 import com.swef.cookcode.user.domain.User;
@@ -38,6 +43,8 @@ public class RecipeService {
     private final RecipeRepository recipeRepository;
 
     private final RecipeIngredRepository recipeIngredRepository;
+
+    private final RecipeCommentRepository recipeCommentRepository;
 
     private final StepService stepService;
     private final IngredientSimpleService ingredientSimpleService;
@@ -119,12 +126,6 @@ public class RecipeService {
         recipeIngredRepository.saveAll(recipeIngredList);
     }
 
-    void save(Recipe recipe, List<Ingredient> ingredients) {
-        List<RecipeIngred> recipeIngredList = ingredients.stream()
-                .map(ingredient -> new RecipeIngred(recipe, ingredient, true)).toList();
-        recipeIngredRepository.saveAll(recipeIngredList);
-    }
-
     @Transactional
     void validateCurrentUserIsAuthor(Recipe recipe, User user) {
         if (!Objects.equals(user.getId(), recipe.getAuthor().getId())) throw new PermissionDeniedException(ErrorCode.USER_IS_NOT_AUTHOR);
@@ -172,5 +173,11 @@ public class RecipeService {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
         Slice<RecipeResponse> responses = recipeRepository.searchRecipes(fridgeId, query, isCookable, pageable);
         return responses;
+    }
+
+    public RecipeCommentResponse createComment(User user, Long recipeId, RecipeCommentCreateRequest request) {
+        Recipe recipe = getRecipeById(recipeId);
+        RecipeComment comment = new RecipeComment(recipe, user, request.getComment());
+        return RecipeCommentResponse.from(recipeCommentRepository.save(comment));
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/recipe-comment -> main

## 변경 사항
* 레시피 댓글 작성
* 레시피 댓글 삭제
* 레시피 다건 조회시 댓글 관련 필드 조회되도록 추가
* 레시피 댓글 다건 조회 구현

## 집중했으면 좋은 점
* entity를 create할 때 findById로 가져온 entity에서 getId를 호출해도 쿼리는 나가지 않습니다. 그래서 entity를 생성할 때 getReferenceById를 하지 않아도 됩니다.
* 댓글 작성 API request를 통일하면 좋을 것 같습니다. 논의 후 수정이 필요하면 수정하겠습니다.
* 이 외에 차이가 있는 json field가 발견되거나 통일해야 하는 부분이 있다면 말씀해주시면 감사하겠습니다.
* 오타나 사용되지 않은 메소드가 있다면 말씀해주시면 감사하겠습니다.

## 테스트 결과
<img width="1077" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/e64b746e-6ba6-4934-929a-ac34409aa7f2">

