### PR TITLE
레시피 삭제 시 연관된 객체 처리

### DIFF
--- a/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
+++ b/src/main/java/com/swef/cookcode/cookie/repository/CookieRepository.java
@@ -1,8 +1,15 @@
 package com.swef.cookcode.cookie.repository;
 
 import com.swef.cookcode.cookie.domain.Cookie;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CookieRepository extends JpaRepository<Cookie, Long>, CookieCustomRepository {
+
+    @Modifying
+    @Query("update Cookie c set c.recipe.id = null where c.recipe.id = :recipeId")
+    void updateCookieWhenRecipeDeleted(@Param("recipeId") Long recipeId);
 
 }

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -72,13 +72,12 @@ public class RecipeController {
     }
 
     @PostMapping("/{recipeId}/comments")
-    public ResponseEntity<ApiResponse<CommentResponse>> commentRecipe(@CurrentUser User user, @PathVariable(value = "recipeId") Long recipeId, @RequestBody
+    public ResponseEntity<ApiResponse> commentRecipe(@CurrentUser User user, @PathVariable(value = "recipeId") Long recipeId, @RequestBody
     CommentCreateRequest request) {
-        CommentResponse response = recipeService.createComment(user, recipeId, request);
+        recipeService.createComment(user, recipeId, request);
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 댓글 작성 성공")
                 .status(HttpStatus.OK.value())
-                .data(response)
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/Recipe.java
@@ -51,7 +51,7 @@ public class Recipe extends BaseEntity {
     @Column(nullable = false, length = MAX_THUMBNAIL_LENGTH)
     private String thumbnail;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User author;
 

--- a/src/main/java/com/swef/cookcode/recipe/domain/RecipeIngred.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/RecipeIngred.java
@@ -39,7 +39,7 @@ public class RecipeIngred {
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 
-    @ManyToOne(fetch = FetchType.LAZY,  cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ingred_id")
     private Ingredient ingredient;
 

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCommentRepository.java
@@ -5,9 +5,14 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Long> {
     @Query("select rc from RecipeComment rc join fetch rc.user where rc.recipe.id = :recipeId")
     Slice<RecipeComment> findRecipeComments(@Param("recipeId") Long recipeId, Pageable pageable);
+
+    @Modifying
+    @Query("delete from RecipeComment rc where rc.recipe.id = :recipeId")
+    void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeLikeRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeLikeRepository.java
@@ -4,8 +4,15 @@ import com.swef.cookcode.recipe.domain.RecipeLike;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
 
     Optional<RecipeLike> findByUserIdAndRecipeId(@Param("userId") Long userId, @Param("recipeId") Long recipeId);
+
+
+    @Modifying
+    @Query("delete from RecipeLike rl where rl.recipe.id = :recipeId")
+    void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -8,6 +8,7 @@ import com.swef.cookcode.common.dto.CommentCreateRequest;
 import com.swef.cookcode.common.dto.CommentResponse;
 import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.common.error.exception.PermissionDeniedException;
+import com.swef.cookcode.cookie.repository.CookieRepository;
 import com.swef.cookcode.fridge.domain.Ingredient;
 import com.swef.cookcode.fridge.service.FridgeService;
 import com.swef.cookcode.fridge.service.IngredientSimpleService;
@@ -52,6 +53,8 @@ public class RecipeService {
     private final IngredientSimpleService ingredientSimpleService;
 
     private final RecipeLikeRepository recipeLikeRepository;
+
+    private final CookieRepository cookieRepository;
 
     private final FridgeService fridgeService;
 
@@ -163,6 +166,9 @@ public class RecipeService {
             util.deleteFilesInS3(deletedPhotos);
             util.deleteFilesInS3(deletedVideos);
         });
+        recipeCommentRepository.deleteAllByRecipeId(recipeId);
+        recipeLikeRepository.deleteAllByRecipeId(recipeId);
+        cookieRepository.updateCookieWhenRecipeDeleted(recipeId);
         recipeRepository.delete(recipe);
     }
 

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -181,10 +181,10 @@ public class RecipeService {
     }
 
     @Transactional
-    public CommentResponse createComment(User user, Long recipeId, CommentCreateRequest request) {
+    public void createComment(User user, Long recipeId, CommentCreateRequest request) {
         Recipe recipe = getRecipeById(recipeId);
         RecipeComment comment = new RecipeComment(recipe, user, request.getComment());
-        return CommentResponse.from(recipeCommentRepository.save(comment));
+        recipeCommentRepository.save(comment);
     }
 
     RecipeComment getRecipeCommentById(Long commentId) {


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/recipe-association -> main

## 변경 사항
* 레시피 삭제 시 관련된 레시피 좋아요, 레시피 댓글을 삭제하고, 쿠키의 레시피를 null로 설정해줍니다.

## 집중했으면 좋은 점
* jpa의 arraylist를 clear해주고 있어서 일일히 삭제하는데 추후 수정하겠습니다.
