### PR TITLE
유저가 만든 레시피 조회

### DIFF
--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -161,9 +161,16 @@ public class RecipeController {
     }
 
     @GetMapping("/user/{targetUserId}")
-    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipesOfUser(@CurrentUser User user, @PathVariable(value = "targetUserId") Long userId) {
-
-        return null;
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipesOfUser(@CurrentUser User user, @PathVariable(value = "targetUserId") Long userId,
+                                                                                       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                                       Pageable pageable) {
+        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.getRecipeResponsesOfUser(user, userId, pageable));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("유저의 레시피 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok(apiResponse);
     }
 
     @GetMapping("/{recipeId}")

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -160,6 +160,12 @@ public class RecipeController {
         return ResponseEntity.ok(apiResponse);
     }
 
+    @GetMapping("/user/{targetUserId}")
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipesOfUser(@CurrentUser User user, @PathVariable(value = "targetUserId") Long userId) {
+
+        return null;
+    }
+
     @GetMapping("/{recipeId}")
     public ResponseEntity<ApiResponse<RecipeResponse>> getRecipeById(@CurrentUser User user, @PathVariable("recipeId") Long recipeId) {
 

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface RecipeCustomRepository {
-    Slice<RecipeResponse> findRecipes(Long fridgeId, Long userId, Boolean isCookable, Pageable pageable);
+    Slice<RecipeResponse> findRecipes(Long userId, Boolean isCookable, Pageable pageable);
 
-    Slice<RecipeResponse> searchRecipes(Long fridgeId, Long userId, String query, Boolean isCookable, Pageable pageable);
+    Slice<RecipeResponse> searchRecipes(Long userId, String query, Boolean isCookable, Pageable pageable);
 
-    Slice<RecipeResponse> findRecipesOfUser(Long fridgeId, Long userId, Long targetUserId, Pageable pageable);
+    Slice<RecipeResponse> findRecipesOfUser(Long userId, Long targetUserId, Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
@@ -9,4 +9,6 @@ public interface RecipeCustomRepository {
     Slice<RecipeResponse> findRecipes(Long fridgeId, Long userId, Boolean isCookable, Pageable pageable);
 
     Slice<RecipeResponse> searchRecipes(Long fridgeId, Long userId, String query, Boolean isCookable, Pageable pageable);
+
+    Slice<RecipeResponse> findRecipesOfUser(Long fridgeId, Long userId, Long targetUserId, Pageable pageable);
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
@@ -43,6 +43,16 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
     }
 
     @Override
+    public Slice<RecipeResponse> findRecipesOfUser(Long fridgeId, Long userId, Long targetUserId, Pageable pageable) {
+        JPAQuery<RecipeResponse> query = selectRecipesWithCookableAndLike(fridgeId, userId)
+                .where(recipe.author.id.eq(targetUserId))
+                .groupBy(recipe.id);
+        List<RecipeResponse> result = query.orderBy(recipe.createdAt.desc()).offset(pageable.getOffset()).limit(
+                pageable.getPageSize()+1).fetch();
+        return new SliceImpl<>(result, pageable, hasNextInSlice(result, pageable));
+    }
+
+    @Override
     public Slice<RecipeResponse> searchRecipes(Long fridgeId, Long userId, String searchQuery, Boolean isCookable, Pageable pageable) {
         JPAQuery<RecipeResponse> query = selectRecipesWithCookableAndLike(fridgeId, userId)
                 .where(recipeSearchContains(searchQuery))

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -26,6 +26,7 @@ import com.swef.cookcode.recipe.repository.RecipeIngredRepository;
 import com.swef.cookcode.recipe.repository.RecipeLikeRepository;
 import com.swef.cookcode.recipe.repository.RecipeRepository;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserSimpleService;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,6 +52,8 @@ public class RecipeService {
 
     private final StepService stepService;
     private final IngredientSimpleService ingredientSimpleService;
+
+    private final UserSimpleService userSimpleService;
 
     private final RecipeLikeRepository recipeLikeRepository;
 
@@ -174,22 +177,20 @@ public class RecipeService {
 
     @Transactional(readOnly = true)
     public Slice<RecipeResponse> getRecipeResponses(User user, Boolean isCookable, Integer month, Pageable pageable) {
-        Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
-        Slice<RecipeResponse> responses = recipeRepository.findRecipes(fridgeId, user.getId(), isCookable, pageable);
+        Slice<RecipeResponse> responses = recipeRepository.findRecipes(user.getId(), isCookable, pageable);
         return responses;
     }
 
     @Transactional(readOnly = true)
     public Slice<RecipeResponse> getRecipeResponsesOfUser(User user, Long targetUserId, Pageable pageable) {
-        Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
-        Slice<RecipeResponse> responses = recipeRepository.findRecipesOfUser(fridgeId, user.getId(), targetUserId, pageable);
+        userSimpleService.checkUserExists(targetUserId);
+        Slice<RecipeResponse> responses = recipeRepository.findRecipesOfUser(user.getId(), targetUserId, pageable);
         return responses;
     }
 
     @Transactional(readOnly = true)
     public Slice<RecipeResponse> searchRecipesWith(User user, String query, Boolean isCookable, Pageable pageable) {
-        Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
-        Slice<RecipeResponse> responses = recipeRepository.searchRecipes(fridgeId, user.getId(), query, isCookable, pageable);
+        Slice<RecipeResponse> responses = recipeRepository.searchRecipes(user.getId(), query, isCookable, pageable);
         return responses;
     }
 

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -180,6 +180,13 @@ public class RecipeService {
     }
 
     @Transactional(readOnly = true)
+    public Slice<RecipeResponse> getRecipeResponsesOfUser(User user, Long targetUserId, Pageable pageable) {
+        Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
+        Slice<RecipeResponse> responses = recipeRepository.findRecipesOfUser(fridgeId, user.getId(), targetUserId, pageable);
+        return responses;
+    }
+
+    @Transactional(readOnly = true)
     public Slice<RecipeResponse> searchRecipesWith(User user, String query, Boolean isCookable, Pageable pageable) {
         Long fridgeId = fridgeService.getFridgeOfUser(user).getId();
         Slice<RecipeResponse> responses = recipeRepository.searchRecipes(fridgeId, user.getId(), query, isCookable, pageable);


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/recipe-of-user -> main

## 변경 사항
* 유저가 만든 레시피 조회 api를 구현했습니다.
* 기존 레시피 다건 조회들에서 fridgeId를 service에서 조회하여 쿼리가 하나 더 나갔었는데 이를 서브쿼리로 대체하여 나가는 쿼리를 하나 줄였습니다.
