### PR TITLE
유저의 프로필이미지 수정

### DIFF
--- a/src/main/java/com/swef/cookcode/common/Util.java
+++ b/src/main/java/com/swef/cookcode/common/Util.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.common;
 
+import com.swef.cookcode.common.dto.UrlResponse;
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.util.S3Util;
 import java.util.HashSet;

--- a/src/main/java/com/swef/cookcode/common/dto/UrlResponse.java
+++ b/src/main/java/com/swef/cookcode/common/dto/UrlResponse.java
@@ -1,5 +1,6 @@
-package com.swef.cookcode.common;
+package com.swef.cookcode.common.dto;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -2,7 +2,7 @@ package com.swef.cookcode.recipe.controller;
 
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.SliceResponse;
-import com.swef.cookcode.common.UrlResponse;
+import com.swef.cookcode.common.dto.UrlResponse;
 import com.swef.cookcode.common.Util;
 import com.swef.cookcode.common.dto.CommentCreateRequest;
 import com.swef.cookcode.common.dto.CommentResponse;

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -4,13 +4,14 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.swef.cookcode.common.ApiResponse;
-import com.swef.cookcode.common.PageResponse;
 import com.swef.cookcode.common.SliceResponse;
+import com.swef.cookcode.common.UrlResponse;
 import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.common.jwt.JwtAuthenticationToken;
 import com.swef.cookcode.common.jwt.JwtPrincipal;
 import com.swef.cookcode.fridge.service.FridgeService;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.request.ProfileImageUpdateRequest;
 import com.swef.cookcode.user.dto.request.UserSignInRequest;
 import com.swef.cookcode.user.dto.request.UserSignUpRequest;
 import com.swef.cookcode.user.dto.response.SignInResponse;
@@ -22,7 +23,6 @@ import com.swef.cookcode.user.service.UserService;
 import com.swef.cookcode.user.service.UserSimpleService;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -36,13 +36,16 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("api/v1/account")
@@ -118,6 +121,12 @@ public class AccountController {
                 .data(res)
                 .build();
         return ResponseEntity.ok(apiResponse);
+    }
+
+    @PatchMapping("/profileImage")
+    public ResponseEntity<ApiResponse<UrlResponse>> updateProfileImage(@CurrentUser User user, @RequestPart(value = "profileImage") MultipartFile profileImage) {
+        UrlResponse response = userService.updateProfileImage(user, profileImage);
+        return null;
     }
 
     @PatchMapping

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -5,13 +5,12 @@ import static org.springframework.http.HttpStatus.OK;
 
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.SliceResponse;
-import com.swef.cookcode.common.UrlResponse;
+import com.swef.cookcode.common.dto.UrlResponse;
 import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.common.jwt.JwtAuthenticationToken;
 import com.swef.cookcode.common.jwt.JwtPrincipal;
 import com.swef.cookcode.fridge.service.FridgeService;
 import com.swef.cookcode.user.domain.User;
-import com.swef.cookcode.user.dto.request.ProfileImageUpdateRequest;
 import com.swef.cookcode.user.dto.request.UserSignInRequest;
 import com.swef.cookcode.user.dto.request.UserSignUpRequest;
 import com.swef.cookcode.user.dto.response.SignInResponse;
@@ -36,7 +35,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -124,9 +122,14 @@ public class AccountController {
     }
 
     @PatchMapping("/profileImage")
-    public ResponseEntity<ApiResponse<UrlResponse>> updateProfileImage(@CurrentUser User user, @RequestPart(value = "profileImage") MultipartFile profileImage) {
+    public ResponseEntity<ApiResponse<UrlResponse>> updateProfileImage(@CurrentUser User user, @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
         UrlResponse response = userService.updateProfileImage(user, profileImage);
-        return null;
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("유저의 프로필 이미지 수정 성공")
+                .status(OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok(apiResponse);
     }
 
     @PatchMapping

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -3,10 +3,9 @@ package com.swef.cookcode.user.service;
 import static com.swef.cookcode.common.ErrorCode.LOGIN_PARAM_REQUIRED;
 import static com.swef.cookcode.common.ErrorCode.USER_ALREADY_EXISTS;
 import static com.swef.cookcode.common.ErrorCode.USER_NOT_FOUND;
-import static java.util.Objects.nonNull;
 import static org.springframework.util.StringUtils.hasText;
 
-import com.swef.cookcode.common.UrlResponse;
+import com.swef.cookcode.common.dto.UrlResponse;
 import com.swef.cookcode.common.error.exception.AlreadyExistsException;
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.error.exception.NotFoundException;
@@ -14,19 +13,19 @@ import com.swef.cookcode.common.util.S3Util;
 import com.swef.cookcode.user.domain.Authority;
 import com.swef.cookcode.user.domain.Subscribe;
 import com.swef.cookcode.user.domain.User;
-import com.swef.cookcode.user.dto.request.ProfileImageUpdateRequest;
 import com.swef.cookcode.user.dto.request.UserSignUpRequest;
 import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import com.swef.cookcode.user.repository.SubscribeRepository;
 import com.swef.cookcode.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -42,11 +41,10 @@ public class UserService {
     private final S3Util s3Util;
 
     private final static String PROFILEIMAGE_DIRECTORY = "profileImage";
-
     @Transactional
     public UrlResponse updateProfileImage(User user, MultipartFile profileImage) {
-        String newUrl = null;
-        if (nonNull(profileImage)) {
+        String newUrl = "";
+        if (!profileImage.isEmpty()) {
             newUrl = s3Util.upload(profileImage, PROFILEIMAGE_DIRECTORY);
         }
         if (hasText(user.getProfileImage())) {
@@ -55,7 +53,8 @@ public class UserService {
         user.updateProfileImage(newUrl);
         userRepository.save(user);
         return UrlResponse.builder()
-                .urls(List.of(newUrl)).build();
+                .urls(List.of(newUrl))
+                .build();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/enroll-profileImage -> main

## 변경 사항
* 유저의 프로필 이미지 수정 api 구현하였습니다.

## 집중했으면 좋은 점
* hasText 사용

## 테스트 결과
<img width="1131" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/b3b93162-5f26-403c-92a4-158503bbb828">
<img width="1131" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/1c57e582-99c5-4099-8500-2ff177d20421">

