### PR TITLE
레시피 단건조회 querydsl 사용하도록 변경

### DIFF
--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -178,8 +178,8 @@ public class RecipeController {
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("레시피 세부 조회 성공")
-                .status(HttpStatus.CREATED.value())
-                .data(recipeService.getRecipeResponseById(recipeId))
+                .status(HttpStatus.OK.value())
+                .data(recipeService.getRecipeResponseById(user, recipeId))
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
@@ -1,6 +1,7 @@
 package com.swef.cookcode.recipe.repository;
 
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,4 +12,6 @@ public interface RecipeCustomRepository {
     Slice<RecipeResponse> searchRecipes(Long userId, String query, Boolean isCookable, Pageable pageable);
 
     Slice<RecipeResponse> findRecipesOfUser(Long userId, Long targetUserId, Pageable pageable);
+
+    Optional<RecipeResponse> findRecipeById(Long userId, Long recipeId);
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepository.java
@@ -1,25 +1,10 @@
 package com.swef.cookcode.recipe.repository;
 
 import com.swef.cookcode.recipe.domain.Recipe;
-import com.swef.cookcode.recipe.dto.response.RecipeResponse;
-import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long>, RecipeCustomRepository {
 
-    @EntityGraph(
-            attributePaths = {"author", "steps"}, type = EntityGraphType.FETCH
-    )
-    Optional<Recipe> findAllElementsById(Long id);
-
     boolean existsById(Long recipeId);
-
-
 
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
@@ -18,6 +18,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.swef.cookcode.recipe.domain.QRecipeLike;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -50,6 +51,15 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
         List<RecipeResponse> result = query.orderBy(recipe.createdAt.desc()).offset(pageable.getOffset()).limit(
                 pageable.getPageSize()+1).fetch();
         return new SliceImpl<>(result, pageable, hasNextInSlice(result, pageable));
+    }
+
+    @Override
+    public Optional<RecipeResponse> findRecipeById(Long userId, Long recipeId) {
+        RecipeResponse response = selectRecipesWithCookableAndLike(userId)
+                .where(recipe.id.eq(recipeId))
+                .groupBy(recipe.id)
+                .fetchFirst();
+        return Optional.ofNullable(response);
     }
 
     @Override

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -116,12 +116,9 @@ public class RecipeService {
         });
     }
 
-    // TODO : Recipe fetch 할 때 validation 안되서 임의로 추가.
     @Transactional(readOnly = true)
-    public RecipeResponse getRecipeResponseById(Long recipeId) {
-        validateRecipeById(recipeId);
-        Recipe recipe = recipeRepository.findAllElementsById(recipeId).orElseThrow(() -> new NotFoundException(ErrorCode.RECIPE_NOT_FOUND));
-        return RecipeResponse.from(recipe);
+    public RecipeResponse getRecipeResponseById(User user, Long recipeId) {
+        return recipeRepository.findRecipeById(user.getId(), recipeId).orElseThrow(() -> new NotFoundException(ErrorCode.RECIPE_NOT_FOUND));
     }
 
     void saveNecessaryIngredientsOfRecipe(Recipe recipe, List<Ingredient> ingredients) {


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/recipe-detail -> main

## 변경 사항
레시피 단건 조회 시, 기존 jpa repository의 entity graph를 사용하여 세부 정보들을 가져오는 것을 query dsl을 사용하도록 하여 isLiked 등의 값들이 추가되도록 수정하였습니다.

## 집중했으면 좋은 점
CustomRepository에서 Optional을 반환하게 한 점

## 테스트 결과
<img width="1131" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/ed360b9a-6a37-4c22-9d5a-d14f7e0413e6">

