### PR TITLE
프로필 이미지 버그 수정

### DIFF
--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -20,8 +20,6 @@ import com.swef.cookcode.user.repository.SubscribeRepository;
 import com.swef.cookcode.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.swef.cookcode.user.service;
 import static com.swef.cookcode.common.ErrorCode.LOGIN_PARAM_REQUIRED;
 import static com.swef.cookcode.common.ErrorCode.USER_ALREADY_EXISTS;
 import static com.swef.cookcode.common.ErrorCode.USER_NOT_FOUND;
+import static java.util.Objects.nonNull;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.swef.cookcode.common.dto.UrlResponse;
@@ -44,7 +45,7 @@ public class UserService {
     @Transactional
     public UrlResponse updateProfileImage(User user, MultipartFile profileImage) {
         String newUrl = "";
-        if (!profileImage.isEmpty()) {
+        if (nonNull(profileImage) && !profileImage.isEmpty()) {
             newUrl = s3Util.upload(profileImage, PROFILEIMAGE_DIRECTORY);
         }
         if (hasText(user.getProfileImage())) {


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/profileImage -> main

## 변경 사항
* profileImage가 null일 때 profileImage.isEmpty() 메소드를 호출하여 에러가 발생했음
* 조건문에 nonNull을 추가하여 null safe하도록 변경함.
