### PR TITLE
레시피 상세 조회 시 스텝 가지고 오도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ ingredient_init.sql
 application-aws.yml
 application-local.yml
 application-dev.yml
+application-mail.yml
 ingredient_init.sql
 ./cookcode-secret/*
 /logs

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeDetailResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeDetailResponse.java
@@ -1,0 +1,16 @@
+package com.swef.cookcode.recipe.dto.response;
+
+import com.swef.cookcode.recipe.domain.Recipe;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class RecipeDetailResponse extends RecipeResponse{
+
+    private final List<StepResponse> steps;
+
+    public RecipeDetailResponse(Recipe recipe, Boolean isCookable, Long likeCount, Boolean isLiked, Long commentCount) {
+        super(recipe, isCookable, likeCount, isLiked, commentCount);
+        this.steps = recipe.getSteps().stream().map(s -> StepResponse.from(s, s.getPhotos(), s.getVideos())).toList();
+    }
+}

--- a/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/swef/cookcode/recipe/dto/response/RecipeResponse.java
@@ -31,8 +31,6 @@ public class RecipeResponse {
 
     private List<IngredSimpleResponse> optionalIngredients;
 
-    private List<StepResponse> steps;
-
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
@@ -60,35 +58,6 @@ public class RecipeResponse {
         this.likeCount = likeCount;
         this.isLiked = isLiked;
         this.commentCount = commentCount;
-    }
-
-    public static RecipeResponse from(Recipe recipe) {
-        return RecipeResponse.builder()
-                .recipeId(recipe.getId())
-                .user(UserSimpleResponse.from(recipe.getAuthor()))
-                .title(recipe.getTitle())
-                .description(recipe.getDescription())
-                .ingredients(convert(recipe.getNecessaryIngredients()))
-                .optionalIngredients(convert(recipe.getOptionalIngredients()))
-                .steps(recipe.getSteps().stream().map(s -> StepResponse.from(s, s.getPhotos(), s.getVideos())).toList())
-                .createdAt(recipe.getCreatedAt())
-                .updatedAt(recipe.getUpdatedAt())
-                .thumbnail(recipe.getThumbnail())
-                .build();
-    }
-
-    public static RecipeResponse getMeta(Recipe recipe) {
-        return RecipeResponse.builder()
-                .recipeId(recipe.getId())
-                .user(UserSimpleResponse.from(recipe.getAuthor()))
-                .title(recipe.getTitle())
-                .description(recipe.getDescription())
-                .ingredients(convert(recipe.getNecessaryIngredients()))
-                .optionalIngredients(convert(recipe.getOptionalIngredients()))
-                .createdAt(recipe.getCreatedAt())
-                .updatedAt(recipe.getUpdatedAt())
-                .thumbnail(recipe.getThumbnail())
-                .build();
     }
 
     private static List<IngredSimpleResponse> convert(List<RecipeIngred> ingreds) {

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.swef.cookcode.recipe.domain.QRecipeLike;
+import com.swef.cookcode.recipe.dto.response.RecipeDetailResponse;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
 import java.util.List;
 import java.util.Optional;
@@ -55,7 +56,7 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
 
     @Override
     public Optional<RecipeResponse> findRecipeById(Long userId, Long recipeId) {
-        RecipeResponse response = selectRecipesWithCookableAndLike(userId)
+        RecipeResponse response = selectDetailRecipeWithCookableAndLike(userId)
                 .where(recipe.id.eq(recipeId))
                 .groupBy(recipe.id)
                 .fetchFirst();
@@ -75,7 +76,15 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
     }
 
     private JPAQuery<RecipeResponse> selectRecipesWithCookableAndLike(Long userId) {
-        return queryFactory.select(Projections.constructor(RecipeResponse.class,
+        return selectRecipesWithCookableAndLike(userId, RecipeResponse.class);
+    }
+
+    private JPAQuery<RecipeDetailResponse> selectDetailRecipeWithCookableAndLike(Long userId) {
+        return selectRecipesWithCookableAndLike(userId, RecipeDetailResponse.class);
+    }
+
+    private <T> JPAQuery<T> selectRecipesWithCookableAndLike(Long userId, Class<T> tClass) {
+        return queryFactory.select(Projections.constructor(tClass,
                         recipe,
                         isCookableExpression().as("isCookable"),
                         recipeLike.countDistinct().as("likeCount"),


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/recipe-detail -> main

## 변경 사항
query dsl respository에서 recipe 상세 조회 시 step을 들고 오지 않았음. 
DetailResponse dto를 하나 더 만들어서 이를 해결함.

## 집중했으면 좋은 점
RecipeDetailResponse가 RecipeResponse를 상속받도록 만들어서 dto 사용하는 코드에서는 수정량을 줄일 수 있도록 함.
매개변수의 타입 클래스를 통해 코드 중복을 줄임.

## 테스트 결과
<img width="1035" alt="image" src="https://github.com/ajou-swef/cookcode-backend/assets/52846807/b2553f16-94e4-4a8b-8b92-d58cc73322fb">

