### PR TITLE
유저의 인플루언서 권한 신청 및 관리자의 권한 승인/거부

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
     //thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.5'
+    id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 

--- a/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
+++ b/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
@@ -2,8 +2,11 @@ package com.swef.cookcode.admin.controller;
 
 import com.swef.cookcode.admin.service.AdminService;
 import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.dto.EmailMessage;
 import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.common.util.EmailUtil;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserSimpleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +23,17 @@ public class AdminController {
 
     private final AdminService adminService;
 
+    private final UserSimpleService userSimpleService;
+
+    private final EmailUtil emailUtil;
+
     @PatchMapping("/authorization/{userId}/{isAccept}")
     public ResponseEntity<ApiResponse> authorizePermissionOfUser(@CurrentUser User user, @PathVariable(value = "userId") Long userId, @PathVariable(value = "isAccept") Boolean isAccept) {
-        adminService.authorizeUser(user, userId, isAccept);
+        User targetUser = userSimpleService.getUserById(userId);
+        adminService.validateUserAuthorityForRequest(targetUser);
+        EmailMessage message = adminService.createMessageForNotification(targetUser, isAccept);
+        adminService.authorizeUser(user, targetUser, isAccept);
+        emailUtil.sendMessage(message);
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("권한 처리 성공")
                 .status(HttpStatus.OK.value())

--- a/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
+++ b/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
@@ -1,0 +1,32 @@
+package com.swef.cookcode.admin.controller;
+
+import com.swef.cookcode.admin.service.AdminService;
+import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/admin")
+@RequiredArgsConstructor
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PatchMapping("/authorization/{userId}/{isAccept}")
+    public ResponseEntity<ApiResponse> authorizePermissionOfUser(@CurrentUser User user, @PathVariable(value = "userId") Long userId, @PathVariable(value = "isAccept") Boolean isAccept) {
+        adminService.authorizeUser(user, userId, isAccept);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("권한 처리 성공")
+                .status(HttpStatus.OK.value())
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+}

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -36,7 +36,6 @@ public class AdminService {
     @Transactional
     public void authorizeUser(User user, User targetUser, Boolean isAccept) {
         if (user.getId().equals(targetUser.getId())) throw new InvalidRequestException(ErrorCode.UPGRADE_MYSELF);
-        if (user.getAuthority() != Authority.ADMIN) throw new PermissionDeniedException(ErrorCode.USER_NOT_ALLOWED);
         if (isAccept) {
             userService.validateInitialConditionOfInfluencer(targetUser.getId());
             targetUser.updateAuthority(targetUser.getStatus().getAuthority());

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -1,0 +1,17 @@
+package com.swef.cookcode.admin.service;
+
+import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    @Transactional
+    public void authorizeUser(User user, Long userId, Boolean isAccept) {
+
+    }
+}

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 
 import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.dto.EmailMessage;
+import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.common.error.exception.PermissionDeniedException;
 import com.swef.cookcode.user.domain.Authority;
@@ -34,6 +35,7 @@ public class AdminService {
     }
     @Transactional
     public void authorizeUser(User user, User targetUser, Boolean isAccept) {
+        if (user.getId().equals(targetUser.getId())) throw new InvalidRequestException(ErrorCode.UPGRADE_MYSELF);
         if (user.getAuthority() != Authority.ADMIN) throw new PermissionDeniedException(ErrorCode.USER_NOT_ALLOWED);
         if (isAccept) {
             userService.validateInitialConditionOfInfluencer(targetUser.getId());

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -1,17 +1,58 @@
 package com.swef.cookcode.admin.service;
 
-import com.swef.cookcode.common.entity.CurrentUser;
+import static java.util.Objects.isNull;
+
+import com.swef.cookcode.common.ErrorCode;
+import com.swef.cookcode.common.dto.EmailMessage;
+import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.common.error.exception.PermissionDeniedException;
+import com.swef.cookcode.user.domain.Authority;
+import com.swef.cookcode.user.domain.Status;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.repository.UserRepository;
+import com.swef.cookcode.user.service.UserService;
+import com.swef.cookcode.user.service.UserSimpleService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminService {
 
-    @Transactional
-    public void authorizeUser(User user, Long userId, Boolean isAccept) {
+    // TODO : 권한 처리 security로
 
+    private final UserRepository userRepository;
+
+    private final UserService userService;
+
+    public void validateUserAuthorityForRequest(User targetUser) {
+        Authority authority = targetUser.getStatus().getAuthority();
+        if (isNull(authority)) throw new NotFoundException(ErrorCode.INVALID_AUTHORITY);
+    }
+    @Transactional
+    public void authorizeUser(User user, User targetUser, Boolean isAccept) {
+        if (user.getAuthority() != Authority.ADMIN) throw new PermissionDeniedException(ErrorCode.USER_NOT_ALLOWED);
+        if (isAccept) {
+            userService.validateInitialConditionOfInfluencer(targetUser.getId());
+            targetUser.updateAuthority(targetUser.getStatus().getAuthority());
+        }
+        targetUser.changeStatus(Status.VALID);
+        userRepository.save(targetUser);
+    }
+
+    public EmailMessage createMessageForNotification(User receiver, Boolean isAccept) {
+        String authority = receiver.getStatus().getAuthority().getConsoleValue();
+        String title = "[cookcode] "+authority+" 권한 심사 결과 안내해드립니다.";
+        String content;
+        if (isAccept) {
+            content = receiver.getNickname() + "님, 축하드립니다.<br/>귀하는 " + authority + " 권한 심사에 통과되었습니다.<br/>귀하의 활발한 활동을 기대하며, 앞으로도 응원하겠습니다.";
+        }
+        else {
+            content = receiver.getNickname() + "님, 죄송합니다.<br/>귀하는 " + authority + " 권한 심사에서 탈락되었습니다.<br/>";
+        }
+        return EmailMessage.createMessage(receiver.getEmail(), title, content);
     }
 }

--- a/src/main/java/com/swef/cookcode/common/ErrorCode.java
+++ b/src/main/java/com/swef/cookcode/common/ErrorCode.java
@@ -48,6 +48,8 @@ public enum ErrorCode {
   INVALID_TOKEN_PROCESSING(400, "U023", "올바르지 않은 토큰 형식입니다."),
   INVALID_AUTHORITY(400, "U024", "알 수 없는 권한입니다."),
   INFLUENCER_FALL(400, "U025", "인플루언서 초기 권한 미달입니다."),
+  SUBSCRIBE_MYSELF(400, "U026", "본인을 구독할 수 없습니다."),
+  UPGRADE_MYSELF(400, "U027", "본인을 승인할 수 없습니다."),
 
   /*
   Ingredient Domain

--- a/src/main/java/com/swef/cookcode/common/ErrorCode.java
+++ b/src/main/java/com/swef/cookcode/common/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
   INVALID_TOKEN_SIGN(400, "U022", "토큰의 서명이 올바르지 않습니다"),
 
   INVALID_TOKEN_PROCESSING(400, "U023", "올바르지 않은 토큰 형식입니다."),
+  INVALID_AUTHORITY(400, "U024", "알 수 없는 권한입니다."),
+  INFLUENCER_FALL(400, "U025", "인플루언서 초기 권한 미달입니다."),
 
   /*
   Ingredient Domain

--- a/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -71,33 +72,34 @@ public class WebSecurityConfig {
     }
 
     @Bean
+    RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_INFLUENCER > ROLE_USER");
+        return roleHierarchy;
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(
             HttpSecurity http,
             JwtAuthenticationFilter jwtAuthenticationFilter,
             AccessDeniedHandler accessDeniedHandler,
             AuthenticationEntryPoint authenticationEntryPoint
     ) throws Exception {
-        http
-                .cors()
-                .and()
-                .csrf()
-                .disable()
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .authorizeHttpRequests()
-                .requestMatchers(HttpMethod.GET, "/api/v1/account/password").permitAll()
-                .requestMatchers("/api/v1/account/signin", "/api/v1/account/signup", "/api/v1/account/check", "/health", "/api/v1/account/email").permitAll()
-                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .exceptionHandling()
-                .accessDeniedHandler(accessDeniedHandler)
-                .authenticationEntryPoint(authenticationEntryPoint)
-                .and()
+        return http.authorizeHttpRequests(requests -> {
+                    requests
+                    .requestMatchers(HttpMethod.GET, "/api/v1/account/password").permitAll()
+                    .requestMatchers("/api/v1/account/signin", "/api/v1/account/signup", "/api/v1/account/check", "/health", "/api/v1/account/email").permitAll()
+                    .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                    .anyRequest().hasRole("USER");
+                }).cors(it -> {})
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(it -> {
+                    it.accessDeniedHandler(accessDeniedHandler);
+                    it.authenticationEntryPoint(authenticationEntryPoint);
+                })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
-
-        return http.build();
+                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class)
+                .build();
     }
 }

--- a/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
@@ -13,6 +13,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.access.vote.RoleHierarchyVoter;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -85,6 +88,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers(HttpMethod.GET, "/api/v1/account/password").permitAll()
                 .requestMatchers("/api/v1/account/signin", "/api/v1/account/signup", "/api/v1/account/check", "/health", "/api/v1/account/email").permitAll()
+                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/swef/cookcode/common/dto/EmailMessage.java
+++ b/src/main/java/com/swef/cookcode/common/dto/EmailMessage.java
@@ -14,11 +14,16 @@ public class EmailMessage {
     private String buttonValue;
 
     public static EmailMessage createMessage(String receiver, String title, String content, String specialContent) {
+        EmailMessage message = createMessage(receiver, title, content);
+        message.setButtonValue(specialContent);
+        return message;
+    }
+
+    public static EmailMessage createMessage(String receiver, String title, String content) {
         return EmailMessage.builder()
                 .receiver(receiver)
                 .title(title)
                 .content(content)
-                .buttonValue(specialContent)
                 .build();
     }
 }

--- a/src/main/java/com/swef/cookcode/common/util/EmailUtil.java
+++ b/src/main/java/com/swef/cookcode/common/util/EmailUtil.java
@@ -1,5 +1,7 @@
 package com.swef.cookcode.common.util;
 
+import static java.util.Objects.isNull;
+
 import com.swef.cookcode.common.config.EmailConfig;
 import com.swef.cookcode.common.dto.EmailMessage;
 import jakarta.mail.MessagingException;
@@ -7,6 +9,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -32,13 +35,13 @@ public class EmailUtil {
             messageHelper.setFrom("cookcode <"+emailConfig.getUsername()+">");
             messageHelper.setTo(message.getReceiver());
             messageHelper.setSubject(message.getTitle());
-            messageHelper.setText(setContext(message.getContent(), message.getButtonValue()), true);
+            String text = isNull(message.getButtonValue()) ? setContext(message.getContent()) : setContext(message.getContent(), message.getButtonValue());
+            messageHelper.setText(text, true);
             mailSender.send(mimeMessage);
-        } catch (MessagingException e) {
+        } catch (MessagingException | MailException e) {
             logger.warn(e.getMessage());
         }
     }
-
 
     private String setContext(String content, String code) {
         Context context = new Context();
@@ -46,4 +49,11 @@ public class EmailUtil {
         context.setVariable("buttonValue", code);
         return templateEngine.process("mail", context);
     }
+
+    private String setContext(String content) {
+        Context context = new Context();
+        context.setVariable("content", content);
+        return templateEngine.process("mailForAuthorization", context);
+    }
+
 }

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -15,6 +15,8 @@ import com.swef.cookcode.common.jwt.JwtPrincipal;
 import com.swef.cookcode.common.util.EmailUtil;
 import com.swef.cookcode.common.util.PasswordUtil;
 import com.swef.cookcode.fridge.service.FridgeService;
+import com.swef.cookcode.user.domain.Authority;
+import com.swef.cookcode.user.domain.Status;
 import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.dto.request.ChangePasswordRequest;
 import com.swef.cookcode.user.dto.request.UserSignInRequest;
@@ -246,6 +248,17 @@ public class AccountController {
         userService.changeToTemporaryPassword(email, code);
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("비밀번호 찾기 통한 임시비밀번호 발급 성공")
+                .status(OK.value())
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @PatchMapping("/authority/{authority}")
+    public ResponseEntity<ApiResponse> upgradeAuthority(@CurrentUser User user, @PathVariable(value = "authority")
+                                                        Authority authority) {
+        userService.requestPermission(user, authority);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("권한 신청 완료")
                 .status(OK.value())
                 .build();
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/swef/cookcode/user/controller/AccountController.java
+++ b/src/main/java/com/swef/cookcode/user/controller/AccountController.java
@@ -227,7 +227,7 @@ public class AccountController {
         if (!Pattern.matches(User.EMAIL_REGEX, email)) throw new InvalidRequestException(INVALID_INPUT_VALUE);
         String code = PasswordUtil.createNumberCode(6);
         String title = "[cookcode] 이메일 인증을 위한 인증 코드 발송해드립니다.";
-        String content = "회원가입을 위해 이메일 인증을 진행해주세요.\n하단의 인증코드를 앱에서 입력해주십시오.";
+        String content = "회원가입을 위해 이메일 인증을 진행해주세요.<br/>하단의 인증코드를 앱에서 입력해주십시오.";
         EmailMessage message = EmailMessage.createMessage(email, title, content, code);
         emailUtil.sendMessage(message);
         ApiResponse apiResponse = ApiResponse.builder()

--- a/src/main/java/com/swef/cookcode/user/domain/Authority.java
+++ b/src/main/java/com/swef/cookcode/user/domain/Authority.java
@@ -1,12 +1,20 @@
 package com.swef.cookcode.user.domain;
 
+import lombok.Getter;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+@Getter
 public enum Authority {
 
-    ADMIN,
-    USER,
-    INFLUENCER;
+    ADMIN("관리자"),
+    USER("사용자"),
+    INFLUENCER("인플루언서");
+
+    private final String consoleValue;
+
+    Authority(String consoleValue) {
+        this.consoleValue = consoleValue;
+    }
 
     public SimpleGrantedAuthority toGrantedAuthority() {
         return new SimpleGrantedAuthority(this.toString());

--- a/src/main/java/com/swef/cookcode/user/domain/Authority.java
+++ b/src/main/java/com/swef/cookcode/user/domain/Authority.java
@@ -17,6 +17,6 @@ public enum Authority {
     }
 
     public SimpleGrantedAuthority toGrantedAuthority() {
-        return new SimpleGrantedAuthority(this.toString());
+        return new SimpleGrantedAuthority("ROLE_" + this.toString());
     }
 }

--- a/src/main/java/com/swef/cookcode/user/domain/Status.java
+++ b/src/main/java/com/swef/cookcode/user/domain/Status.java
@@ -4,5 +4,8 @@ public enum Status {
     BLOCKED,
     VALID,
     INF_REQUESTED,
+
+    ADM_REQUESTED,
+
     QUIT
 }

--- a/src/main/java/com/swef/cookcode/user/domain/Status.java
+++ b/src/main/java/com/swef/cookcode/user/domain/Status.java
@@ -1,11 +1,21 @@
 package com.swef.cookcode.user.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Status {
-    BLOCKED,
-    VALID,
-    INF_REQUESTED,
+    BLOCKED(null),
+    VALID(null),
+    INF_REQUESTED(Authority.INFLUENCER),
 
-    ADM_REQUESTED,
+    ADM_REQUESTED(Authority.ADMIN),
 
-    QUIT
+    QUIT(null);
+
+    private final Authority authority;
+
+
+    Status(Authority authority) {
+        this.authority = authority;
+    }
 }

--- a/src/main/java/com/swef/cookcode/user/domain/User.java
+++ b/src/main/java/com/swef/cookcode/user/domain/User.java
@@ -131,6 +131,10 @@ public class User extends BaseEntity {
         this.password = passwordEncoder.encode(rawPassword);
     }
 
+    public void changeStatus(Status status) {
+        this.status = status;
+    }
+
     public void quit() {
         this.isQuit = true;
         this.status = Status.QUIT;

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -15,6 +15,9 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     Optional<User> findByEmail(@Param("email") String email);
 
+    @Query("select case when count(s.id) > 10 then true else false end from Subscribe s where s.publisher.id = :userId")
+    boolean fulfillInfluencerCondition(@Param("userId") Long userId);
+
     boolean existsByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
 
     boolean existsByNicknameAndIsQuit(@Param("nickname") String nickname, @Param("isQuit") Boolean isQuit);

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -6,10 +6,12 @@ import static com.swef.cookcode.common.ErrorCode.USER_NOT_FOUND;
 import static java.util.Objects.nonNull;
 import static org.springframework.util.StringUtils.hasText;
 
+import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.dto.UrlResponse;
 import com.swef.cookcode.common.error.exception.AlreadyExistsException;
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.error.exception.NotFoundException;
+import com.swef.cookcode.common.error.exception.PermissionDeniedException;
 import com.swef.cookcode.common.util.S3Util;
 import com.swef.cookcode.user.domain.Authority;
 import com.swef.cookcode.user.domain.Status;
@@ -159,5 +161,10 @@ public class UserService {
         if (authority == Authority.INFLUENCER) user.changeStatus(Status.INF_REQUESTED);
         if (authority == Authority.ADMIN) user.changeStatus(Status.ADM_REQUESTED);
         userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public void validateInitialConditionOfInfluencer(Long userId) {
+        if(!userRepository.fulfillInfluencerCondition(userId)) throw new PermissionDeniedException(ErrorCode.INFLUENCER_FALL);
     }
 }

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -116,6 +116,8 @@ public class UserService {
 
     @Transactional
     public void toggleSubscribe(User user, Long createrId) {
+        if (user.getId().equals(createrId)) throw new InvalidRequestException(SUBSCRIBE_MYSELF);
+
         User publisher = userRepository.getReferenceById(createrId);
 
         Optional<Subscribe> subscribeOptional = subscribeRepository.findBySubscriberAndPublisher(user, publisher);

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.swef.cookcode.user.service;
 
 import static com.swef.cookcode.common.ErrorCode.LOGIN_PARAM_REQUIRED;
+import static com.swef.cookcode.common.ErrorCode.SUBSCRIBE_MYSELF;
 import static com.swef.cookcode.common.ErrorCode.USER_ALREADY_EXISTS;
 import static com.swef.cookcode.common.ErrorCode.USER_NOT_FOUND;
 import static java.util.Objects.nonNull;
@@ -158,7 +159,10 @@ public class UserService {
 
     @Transactional
     public void requestPermission(User user, Authority authority) {
-        if (authority == Authority.INFLUENCER) user.changeStatus(Status.INF_REQUESTED);
+        if (authority == Authority.INFLUENCER) {
+            validateInitialConditionOfInfluencer(user.getId());
+            user.changeStatus(Status.INF_REQUESTED);
+        }
         if (authority == Authority.ADMIN) user.changeStatus(Status.ADM_REQUESTED);
         userRepository.save(user);
     }

--- a/src/main/java/com/swef/cookcode/user/service/UserService.java
+++ b/src/main/java/com/swef/cookcode/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.error.exception.NotFoundException;
 import com.swef.cookcode.common.util.S3Util;
 import com.swef.cookcode.user.domain.Authority;
+import com.swef.cookcode.user.domain.Status;
 import com.swef.cookcode.user.domain.Subscribe;
 import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.dto.request.ChangePasswordRequest;
@@ -150,6 +151,13 @@ public class UserService {
     public void changeToTemporaryPassword(String email, String temporaryPassword) {
         User user = userSimpleService.getUserByEmail(email);
         user.changePassword(passwordEncoder, temporaryPassword);
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void requestPermission(User user, Authority authority) {
+        if (authority == Authority.INFLUENCER) user.changeStatus(Status.INF_REQUESTED);
+        if (authority == Authority.ADMIN) user.changeStatus(Status.ADM_REQUESTED);
         userRepository.save(user);
     }
 }

--- a/src/main/resources/templates/mailForAuthorization.html
+++ b/src/main/resources/templates/mailForAuthorization.html
@@ -34,13 +34,6 @@
                                                        th:utext="${content}">
                                                         </p>
 
-                                                    <table style="font-family:'Helvetica Neue','Helvetica',Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5;width:100%;margin: 30px 0 20px;text-align: center;">
-                                                        <tr>
-                                                            <td style="border-radius:8px;background:#FE642E;box-sizing:border-box;color:#ffffff;display:inline-block;font-family:'Helvetica Neue','Helvetica',Helvetica,Arial,sans-serif;font-size:20px;width:100%;font-weight:bold;line-height:1.5;margin:0;padding:12px 25px;text-decoration:none;"
-                                                            th:text="${buttonValue}">
-                                                            </td>
-                                                        </tr>
-                                                    </table>
                                                 </td>
                                             </tr>
                                             </tbody>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/influencer-authorization -> main

## 변경 사항
### 기능 구현
* 관리자 controller 등 관리자 디렉토리 생성
* 유저의 권한 신청
   * influencer, admin에 대해 권한 신청할 수 있음.
* 관리자의 권한 승인/거부 api
* 권한 신청할 때도, 권한 심사할 때도 인플루언서 초기 만족 조건 확인
   * 초기 만족 조건은 일단 구독자 10명으로 해둠.

### 기존 기능 수정
* role hierarchy 편리한 사용을 위한 스프링부트 버전업
* 버전업으로 인한 기존 spring security lambda dsl로 변경 (기존 방식은 추후 deprecated될 예정이라 함)
* 본인이 본인을 구독하는 경우에 대한 validation 처리

### 기타 변경사항
* thymeleaf 심사 관련 메일의 경우 버튼 사용 안함
* 기존 template들 개행이 되도록 수정

## 집중했으면 좋은 점
* 권한 거부/승인 때 놓친 validation 케이스는 없는 지 같이 고민해주셨으면 좋겠습니다.
* 버전업으로 인한 기존 기능에 대한 여파가 살짝 걱정되는데, 추후 확인이 되면 다시 버전 롤백하겠습니다.
* 관리자 / 인플루언서 / 사용자에 대한 권한 관리 role hierarchy로 잘 동작합니다. 