### PR TITLE
관리자의 유저 권한 신청 목록 조회 구현

### DIFF
--- a/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
+++ b/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.admin.controller;
 
+import com.swef.cookcode.admin.dto.EmailUser;
 import com.swef.cookcode.admin.dto.PermissionResponse;
 import com.swef.cookcode.admin.service.AdminService;
 import com.swef.cookcode.common.ApiResponse;
@@ -32,10 +33,8 @@ public class AdminController {
 
     @PatchMapping("/authorization/{userId}/{isAccept}")
     public ResponseEntity<ApiResponse> authorizePermissionOfUser(@CurrentUser User user, @PathVariable(value = "userId") Long userId, @PathVariable(value = "isAccept") Boolean isAccept) {
-        User targetUser = userSimpleService.getUserById(userId);
-        adminService.validateUserAuthorityForRequest(targetUser);
+        EmailUser targetUser = adminService.authorizeUser(user, userId, isAccept);
         EmailMessage message = adminService.createMessageForNotification(targetUser, isAccept);
-        adminService.authorizeUser(user, targetUser, isAccept);
         emailUtil.sendMessage(message);
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("권한 처리 성공")

--- a/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
+++ b/src/main/java/com/swef/cookcode/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.admin.controller;
 
+import com.swef.cookcode.admin.dto.PermissionResponse;
 import com.swef.cookcode.admin.service.AdminService;
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.dto.EmailMessage;
@@ -7,9 +8,11 @@ import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.common.util.EmailUtil;
 import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.service.UserSimpleService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +40,17 @@ public class AdminController {
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("권한 처리 성공")
                 .status(HttpStatus.OK.value())
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @GetMapping("/authorization")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getPermission() {
+        List<PermissionResponse> responses = adminService.getPermissions();
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("유저의 권한 신청 목록 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(responses)
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/swef/cookcode/admin/dto/EmailUser.java
+++ b/src/main/java/com/swef/cookcode/admin/dto/EmailUser.java
@@ -1,0 +1,24 @@
+package com.swef.cookcode.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class EmailUser {
+    private String nickname;
+
+    private String authority;
+
+    private String email;
+
+    public static EmailUser createEmailUser(String nickname, String authority, String email) {
+        return EmailUser.builder()
+                .nickname(nickname)
+                .authority(authority)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/swef/cookcode/admin/dto/PermissionResponse.java
+++ b/src/main/java/com/swef/cookcode/admin/dto/PermissionResponse.java
@@ -1,0 +1,27 @@
+package com.swef.cookcode.admin.dto;
+
+import com.swef.cookcode.user.domain.Authority;
+import com.swef.cookcode.user.domain.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class PermissionResponse {
+    private final Long userId;
+
+    private final Authority authority;
+
+    private final LocalDateTime createdAt;
+
+    public static PermissionResponse from(User user) {
+        return PermissionResponse.builder()
+                .userId(user.getId())
+                .authority(user.getStatus().getAuthority())
+                .createdAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -2,6 +2,7 @@ package com.swef.cookcode.admin.service;
 
 import static java.util.Objects.isNull;
 
+import com.swef.cookcode.admin.dto.PermissionResponse;
 import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.dto.EmailMessage;
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
@@ -13,6 +14,7 @@ import com.swef.cookcode.user.domain.User;
 import com.swef.cookcode.user.repository.UserRepository;
 import com.swef.cookcode.user.service.UserService;
 import com.swef.cookcode.user.service.UserSimpleService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -55,5 +57,11 @@ public class AdminService {
             content = receiver.getNickname() + "님, 죄송합니다.<br/>귀하는 " + authority + " 권한 심사에서 탈락되었습니다.<br/>";
         }
         return EmailMessage.createMessage(receiver.getEmail(), title, content);
+    }
+
+    @Transactional
+    public List<PermissionResponse> getPermissions() {
+        List<User> users = userRepository.getUsersByStatus();
+        return users.stream().map(PermissionResponse::from).toList();
     }
 }

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -2,12 +2,12 @@ package com.swef.cookcode.admin.service;
 
 import static java.util.Objects.isNull;
 
+import com.swef.cookcode.admin.dto.EmailUser;
 import com.swef.cookcode.admin.dto.PermissionResponse;
 import com.swef.cookcode.common.ErrorCode;
 import com.swef.cookcode.common.dto.EmailMessage;
 import com.swef.cookcode.common.error.exception.InvalidRequestException;
 import com.swef.cookcode.common.error.exception.NotFoundException;
-import com.swef.cookcode.common.error.exception.PermissionDeniedException;
 import com.swef.cookcode.user.domain.Authority;
 import com.swef.cookcode.user.domain.Status;
 import com.swef.cookcode.user.domain.User;
@@ -31,32 +31,37 @@ public class AdminService {
 
     private final UserService userService;
 
-    public void validateUserAuthorityForRequest(User targetUser) {
+    private final UserSimpleService userSimpleService;
+
+
+    public Authority validateUserAuthorityForRequest(User targetUser) {
         Authority authority = targetUser.getStatus().getAuthority();
         if (isNull(authority)) throw new NotFoundException(ErrorCode.INVALID_AUTHORITY);
+        return authority;
     }
     @Transactional
-    public void authorizeUser(User user, User targetUser, Boolean isAccept) {
+    public EmailUser authorizeUser(User user, Long targetUserId, Boolean isAccept) {
+        User targetUser = userSimpleService.getUserById(targetUserId);
+        Authority authority = validateUserAuthorityForRequest(targetUser);
         if (user.getId().equals(targetUser.getId())) throw new InvalidRequestException(ErrorCode.UPGRADE_MYSELF);
         if (isAccept) {
-            userService.validateInitialConditionOfInfluencer(targetUser.getId());
+            if (authority == Authority.INFLUENCER) userService.validateInitialConditionOfInfluencer(targetUser.getId());
             targetUser.updateAuthority(targetUser.getStatus().getAuthority());
         }
         targetUser.changeStatus(Status.VALID);
-        userRepository.save(targetUser);
+        return EmailUser.createEmailUser(targetUser.getNickname(), authority.getConsoleValue(), targetUser.getEmail());
     }
 
-    public EmailMessage createMessageForNotification(User receiver, Boolean isAccept) {
-        String authority = receiver.getStatus().getAuthority().getConsoleValue();
-        String title = "[cookcode] "+authority+" 권한 심사 결과 안내해드립니다.";
+    public EmailMessage createMessageForNotification(EmailUser emailUser, Boolean isAccept) {
+        String title = "[cookcode] "+emailUser.getAuthority()+" 권한 심사 결과 안내해드립니다.";
         String content;
         if (isAccept) {
-            content = receiver.getNickname() + "님, 축하드립니다.<br/>귀하는 " + authority + " 권한 심사에 통과되었습니다.<br/>귀하의 활발한 활동을 기대하며, 앞으로도 응원하겠습니다.";
+            content = emailUser.getNickname() + "님, 축하드립니다.<br/>귀하는 " + emailUser.getAuthority() + " 권한 심사에 통과되었습니다.<br/>귀하의 활발한 활동을 기대하며, 앞으로도 응원하겠습니다.";
         }
         else {
-            content = receiver.getNickname() + "님, 죄송합니다.<br/>귀하는 " + authority + " 권한 심사에서 탈락되었습니다.<br/>";
+            content = emailUser.getNickname() + "님, 죄송합니다.<br/>귀하는 " + emailUser.getAuthority() + " 권한 심사에서 탈락되었습니다.<br/>";
         }
-        return EmailMessage.createMessage(receiver.getEmail(), title, content);
+        return EmailMessage.createMessage(emailUser.getEmail(), title, content);
     }
 
     @Transactional

--- a/src/main/java/com/swef/cookcode/admin/service/AdminService.java
+++ b/src/main/java/com/swef/cookcode/admin/service/AdminService.java
@@ -64,7 +64,7 @@ public class AdminService {
         return EmailMessage.createMessage(emailUser.getEmail(), title, content);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PermissionResponse> getPermissions() {
         List<User> users = userRepository.getUsersByStatus();
         return users.stream().map(PermissionResponse::from).toList();

--- a/src/main/java/com/swef/cookcode/user/domain/User.java
+++ b/src/main/java/com/swef/cookcode/user/domain/User.java
@@ -18,6 +18,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -65,6 +66,8 @@ public class User extends BaseEntity {
 
     @Column(length = MAX_PASSWORD_LENGTH)
     private String password;
+
+    private LocalDateTime authorityRequestedAt;
 
     @Builder
     public User(String email, String nickname, String encodedPassword, Authority authority) {

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -16,14 +16,14 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     Optional<User> findByEmail(@Param("email") String email);
 
-    @Query("update User u set u.status = :status where u.id = :userId")
+    @Query("update User u set u.status = :status, u.authorityRequestedAt = CURRENT_TIMESTAMP where u.id = :userId")
     @Modifying
     void updateUserStatus(@Param("status") Status status, @Param("userId") Long userId);
 
     @Query("select case when count(s.id) >= 2 then true else false end from Subscribe s where s.publisher.id = :userId")
     boolean fulfillInfluencerCondition(@Param("userId") Long userId);
 
-    @Query("select u from User u where u.status = 'INF_REQUESTED' or u.status = 'ADM_REQUESTED' order by u.updatedAt desc")
+    @Query("select u from User u where u.status = 'INF_REQUESTED' or u.status = 'ADM_REQUESTED' order by u.authorityRequestedAt desc")
     List<User> getUsersByStatus();
 
     boolean existsByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);

--- a/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
+++ b/src/main/java/com/swef/cookcode/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.swef.cookcode.user.repository;
 import com.swef.cookcode.user.domain.Status;
 import com.swef.cookcode.user.domain.User;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -21,6 +22,9 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     @Query("select case when count(s.id) >= 2 then true else false end from Subscribe s where s.publisher.id = :userId")
     boolean fulfillInfluencerCondition(@Param("userId") Long userId);
+
+    @Query("select u from User u where u.status = 'INF_REQUESTED' or u.status = 'ADM_REQUESTED' order by u.updatedAt desc")
+    List<User> getUsersByStatus();
 
     boolean existsByEmailAndIsQuit(@Param("email") String email, @Param("isQuit") Boolean isQuit);
 


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/permission-request -> main

## 변경 사항
관리자의 유저 권한 신청 목록 조회 구현
* 페이징 적용 없이 일단 List로 구현했습니다.
* user 필드에 authorityRequestedAt이 추가되었습니다.
   * 권한 신청된 시점을 기록합니다.
   * 권한 신청 목록을 조회할 때 권한 신청된 시점에 대한 최신순으로 조회합니다.

## 집중했으면 좋은 점
* 권한 신청 시에 user row가 updatedAt이 최신으로 바뀔 텐데 현재 updatedAt을 유저가 권한 신청한 시점으로 이용하고 있습니다.
* 기존에는 validation을 controller에서 진행하여 service 계층에 준영속 상태인 엔티티가 들어가게 되어서 repository.save 호출 시에 영속화 시키기 위해 update 쿼리 전에 select가 시행됨.
* validation을 service에서 처리하게 하여(entity를 service에서 가져오게 하여) 변경 감지가 동작하게 하도록 리팩토링 함.