### PR TITLE
멤버십 도메인 기능 구현

### DIFF
--- a/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
+++ b/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
@@ -81,4 +81,18 @@ public class MembershipController {
         return ResponseEntity.ok().body(apiResponse);
     }
 
+    @DeleteMapping("/{membershipId}")
+    public ResponseEntity<ApiResponse> deleteJoiningMembership(
+            @CurrentUser User user, @PathVariable Long membershipId){
+
+        membershipService.deleteJoiningMembership(user, membershipId);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("가입 멤버십 탈퇴 성공")
+                .status(HttpStatus.OK.value())
+                .build();
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
 }

--- a/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
+++ b/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
@@ -7,6 +7,7 @@ import com.swef.cookcode.membership.dto.MembershipCreateRequest;
 import com.swef.cookcode.membership.dto.MembershipResponse;
 import com.swef.cookcode.membership.service.MembershipService;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +23,10 @@ public class MembershipController {
     private final MembershipService membershipService;
 
     @GetMapping("/{createrId}")
-    public ResponseEntity<ApiResponse<List<MembershipResponse>>> getMembership(
+    public ResponseEntity<ApiResponse<List<MembershipResponse>>> getCreaterMembership(
             @CurrentUser User user, @PathVariable Long createrId){
 
-        List<MembershipResponse> membershipList = membershipService.getMembership(createrId);
+        List<MembershipResponse> membershipList = membershipService.getCreaterMembership(createrId);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("멤버십 조회 성공")
@@ -59,6 +60,21 @@ public class MembershipController {
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("멤버십 가입 성공")
                 .status(HttpStatus.OK.value())
+                .build();
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<UserSimpleResponse>>> getJoiningMemberships(
+            @CurrentUser User user){
+
+        List<UserSimpleResponse> membershipList = membershipService.getJoiningMemberships(user);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("가입 멤버십 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(membershipList)
                 .build();
 
         return ResponseEntity.ok().body(apiResponse);

--- a/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
+++ b/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
@@ -4,6 +4,7 @@ import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.membership.domain.Membership;
 import com.swef.cookcode.membership.dto.MembershipCreateRequest;
+import com.swef.cookcode.membership.dto.MembershipResponse;
 import com.swef.cookcode.membership.service.MembershipService;
 import com.swef.cookcode.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -15,16 +16,16 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/membeship")
+@RequestMapping("/api/v1/membership")
 public class MembershipController {
 
     private final MembershipService membershipService;
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<List<Membership>>> getMembership(
-            @CurrentUser User user){
+    @GetMapping("/{createrId}")
+    public ResponseEntity<ApiResponse<List<MembershipResponse>>> getMembership(
+            @CurrentUser User user, @PathVariable Long createrId){
 
-        List<Membership> membershipList = membershipService.getMembership(user);
+        List<MembershipResponse> membershipList = membershipService.getMembership(createrId);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("멤버십 조회 성공")

--- a/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
+++ b/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
@@ -3,6 +3,7 @@ package com.swef.cookcode.membership.controller;
 import com.swef.cookcode.common.ApiResponse;
 import com.swef.cookcode.common.entity.CurrentUser;
 import com.swef.cookcode.membership.domain.Membership;
+import com.swef.cookcode.membership.dto.JoiningMembershipResponse;
 import com.swef.cookcode.membership.dto.MembershipCreateRequest;
 import com.swef.cookcode.membership.dto.MembershipResponse;
 import com.swef.cookcode.membership.service.MembershipService;
@@ -66,10 +67,10 @@ public class MembershipController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<UserSimpleResponse>>> getJoiningMemberships(
+    public ResponseEntity<ApiResponse<List<JoiningMembershipResponse>>> getJoiningMemberships(
             @CurrentUser User user){
 
-        List<UserSimpleResponse> membershipList = membershipService.getJoiningMemberships(user);
+        List<JoiningMembershipResponse> membershipList = membershipService.getJoiningMemberships(user);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("가입 멤버십 조회 성공")

--- a/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
+++ b/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
@@ -1,0 +1,52 @@
+package com.swef.cookcode.membership.controller;
+
+import com.swef.cookcode.common.ApiResponse;
+import com.swef.cookcode.common.entity.CurrentUser;
+import com.swef.cookcode.membership.domain.Membership;
+import com.swef.cookcode.membership.dto.MembershipCreateRequest;
+import com.swef.cookcode.membership.service.MembershipService;
+import com.swef.cookcode.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/membeship")
+public class MembershipController {
+
+    private final MembershipService membershipService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<List<Membership>>> getMembership(
+            @CurrentUser User user){
+
+        List<Membership> membershipList = membershipService.getMembership(user);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("멤버십 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(membershipList)
+                .build();
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> createMembership(
+            @CurrentUser User user, @RequestBody MembershipCreateRequest membershipCreateRequest){
+
+        membershipService.createMembership(user, membershipCreateRequest);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("멤버십 생성 성공")
+                .status(HttpStatus.OK.value())
+                .build();
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
+}

--- a/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
+++ b/src/main/java/com/swef/cookcode/membership/controller/MembershipController.java
@@ -49,4 +49,18 @@ public class MembershipController {
         return ResponseEntity.ok().body(apiResponse);
     }
 
+    @PostMapping("/{membershipId}")
+    public ResponseEntity<ApiResponse> joinMembership(
+            @CurrentUser User user, @PathVariable Long membershipId){
+
+        membershipService.joinMembership(user, membershipId);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("멤버십 가입 성공")
+                .status(HttpStatus.OK.value())
+                .build();
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
 }

--- a/src/main/java/com/swef/cookcode/membership/domain/Membership.java
+++ b/src/main/java/com/swef/cookcode/membership/domain/Membership.java
@@ -1,0 +1,42 @@
+package com.swef.cookcode.membership.domain;
+
+import com.swef.cookcode.common.entity.BaseEntity;
+import com.swef.cookcode.membership.dto.MembershipCreateRequest;
+import com.swef.cookcode.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "membership")
+@Getter
+public class Membership extends BaseEntity {
+
+    @Id
+    @Column(name = "membership_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "creater")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creater_id")
+    private User creater;
+
+    @Column(name = "grade")
+    private String grade;
+
+    @Column(name = "price")
+    private Long price;
+
+    private Membership(User creater, String grade, Long price) {
+        this.creater = creater;
+        this.grade = grade;
+        this.price = price;
+    }
+
+    public static Membership createEntity(User creater, MembershipCreateRequest request) {
+        return new Membership(creater, request.getGrade(), request.getPrice());
+    }
+}

--- a/src/main/java/com/swef/cookcode/membership/domain/Membership.java
+++ b/src/main/java/com/swef/cookcode/membership/domain/Membership.java
@@ -19,7 +19,6 @@ public class Membership extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "creater")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creater_id")
     private User creater;

--- a/src/main/java/com/swef/cookcode/membership/domain/MembershipJoin.java
+++ b/src/main/java/com/swef/cookcode/membership/domain/MembershipJoin.java
@@ -1,0 +1,38 @@
+package com.swef.cookcode.membership.domain;
+
+import com.swef.cookcode.common.entity.BaseEntity;
+import com.swef.cookcode.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "membership_join")
+@Getter
+public class MembershipJoin extends BaseEntity {
+
+    @Id
+    @Column(name = "membershipJoin_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "membership_id")
+    private Membership membership;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User subscriber;
+
+    private MembershipJoin(Membership membership, User subscriber) {
+        this.membership = membership;
+        this.subscriber = subscriber;
+    }
+
+    public static MembershipJoin createEntity(Membership membership, User subscriber) {
+        return new MembershipJoin(membership, subscriber);
+    }
+}

--- a/src/main/java/com/swef/cookcode/membership/dto/JoiningMembershipResponse.java
+++ b/src/main/java/com/swef/cookcode/membership/dto/JoiningMembershipResponse.java
@@ -1,0 +1,23 @@
+package com.swef.cookcode.membership.dto;
+
+import com.swef.cookcode.membership.domain.Membership;
+import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JoiningMembershipResponse {
+    private final Long membershipId;
+
+    private final String grade;
+
+    private final Long price;
+
+    private final UserSimpleResponse creater;
+
+    public static JoiningMembershipResponse from(Membership membership) {
+        return new JoiningMembershipResponse(membership.getId(), membership.getGrade(), membership.getPrice(), UserSimpleResponse.from(membership.getCreater()));
+    }
+}

--- a/src/main/java/com/swef/cookcode/membership/dto/MembershipCreateRequest.java
+++ b/src/main/java/com/swef/cookcode/membership/dto/MembershipCreateRequest.java
@@ -1,0 +1,14 @@
+package com.swef.cookcode.membership.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MembershipCreateRequest {
+
+    private String grade;
+
+    private Long price;
+
+}

--- a/src/main/java/com/swef/cookcode/membership/dto/MembershipResponse.java
+++ b/src/main/java/com/swef/cookcode/membership/dto/MembershipResponse.java
@@ -1,0 +1,21 @@
+package com.swef.cookcode.membership.dto;
+
+import com.swef.cookcode.membership.domain.Membership;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class MembershipResponse {
+
+    private final Long membershipId;
+
+    private final String grade;
+
+    private final Long price;
+
+    public static MembershipResponse from(Membership membership) {
+        return new MembershipResponse(membership.getId(), membership.getGrade(), membership.getPrice());
+    }
+}

--- a/src/main/java/com/swef/cookcode/membership/dto/MembershipResponse.java
+++ b/src/main/java/com/swef/cookcode/membership/dto/MembershipResponse.java
@@ -3,7 +3,6 @@ package com.swef.cookcode.membership.dto;
 import com.swef.cookcode.membership.domain.Membership;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
+++ b/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
@@ -1,5 +1,6 @@
 package com.swef.cookcode.membership.repository;
 
+import com.swef.cookcode.membership.domain.Membership;
 import com.swef.cookcode.membership.domain.MembershipJoin;
 import com.swef.cookcode.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,5 @@ public interface MembershipJoinRepository extends JpaRepository<MembershipJoin, 
     @Query("select mj from MembershipJoin mj join fetch mj.membership m join fetch m.creater where mj.subscriber = :user")
     List<MembershipJoin> findBySubscriber(User user);
 
+    void deleteBySubscriberAndMembership(User user, Membership membership);
 }

--- a/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
+++ b/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
@@ -1,0 +1,8 @@
+package com.swef.cookcode.membership.repository;
+
+import com.swef.cookcode.membership.domain.MembershipJoin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MembershipJoinRepository extends JpaRepository<MembershipJoin, Long> {
+
+}

--- a/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
+++ b/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
@@ -1,8 +1,12 @@
 package com.swef.cookcode.membership.repository;
 
 import com.swef.cookcode.membership.domain.MembershipJoin;
+import com.swef.cookcode.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface MembershipJoinRepository extends JpaRepository<MembershipJoin, Long> {
 
+    List<MembershipJoin> findBySubscriber(User user);
 }

--- a/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
+++ b/src/main/java/com/swef/cookcode/membership/repository/MembershipJoinRepository.java
@@ -3,10 +3,13 @@ package com.swef.cookcode.membership.repository;
 import com.swef.cookcode.membership.domain.MembershipJoin;
 import com.swef.cookcode.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface MembershipJoinRepository extends JpaRepository<MembershipJoin, Long> {
 
+    @Query("select mj from MembershipJoin mj join fetch mj.membership m join fetch m.creater where mj.subscriber = :user")
     List<MembershipJoin> findBySubscriber(User user);
+
 }

--- a/src/main/java/com/swef/cookcode/membership/repository/MembershipRepository.java
+++ b/src/main/java/com/swef/cookcode/membership/repository/MembershipRepository.java
@@ -1,0 +1,12 @@
+package com.swef.cookcode.membership.repository;
+
+import com.swef.cookcode.membership.domain.Membership;
+import com.swef.cookcode.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MembershipRepository extends JpaRepository<Membership, Long> {
+
+    List<Membership> findByCreater(User user);
+}

--- a/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
+++ b/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
@@ -58,4 +58,11 @@ public class MembershipService {
                 .map(join -> JoiningMembershipResponse.from(join.getMembership()))
                 .toList();
     }
+
+    @Transactional
+    public void deleteJoiningMembership(User user, Long membershipId) {
+        Membership membership = membershipRepository.getReferenceById(membershipId);
+
+        membershipJoinRepository.deleteBySubscriberAndMembership(user, membership);
+    }
 }

--- a/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
+++ b/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
@@ -1,0 +1,29 @@
+package com.swef.cookcode.membership.service;
+
+import com.swef.cookcode.membership.domain.Membership;
+import com.swef.cookcode.membership.dto.MembershipCreateRequest;
+import com.swef.cookcode.membership.repository.MembershipRepository;
+import com.swef.cookcode.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipService {
+
+    private final MembershipRepository membershipRepository;
+
+    @Transactional
+    public void createMembership(User user, MembershipCreateRequest request) {
+        Membership membership = Membership.createEntity(user, request);
+
+        membershipRepository.save(membership);
+    }
+
+    public List<Membership> getMembership(User user) {
+        return membershipRepository.findByCreater(user);
+    }
+}

--- a/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
+++ b/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
@@ -7,6 +7,7 @@ import com.swef.cookcode.membership.dto.MembershipResponse;
 import com.swef.cookcode.membership.repository.MembershipJoinRepository;
 import com.swef.cookcode.membership.repository.MembershipRepository;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import com.swef.cookcode.user.service.UserSimpleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,7 @@ public class MembershipService {
     }
 
     @Transactional(readOnly = true)
-    public List<MembershipResponse> getMembership(Long createrId) {
+    public List<MembershipResponse> getCreaterMembership(Long createrId) {
         User creater = userSimpleService.getUserById(createrId);
 
         List<Membership> membershipList = membershipRepository.findByCreater(creater);
@@ -46,5 +47,14 @@ public class MembershipService {
         MembershipJoin membershipJoin = MembershipJoin.createEntity(membership, user);
 
         membershipJoinRepository.save(membershipJoin);
+    }
+
+    @Transactional
+    public List<UserSimpleResponse> getJoiningMemberships(User user) {
+        List<MembershipJoin> joiningMemberships = membershipJoinRepository.findBySubscriber(user);
+
+        return joiningMemberships.stream()
+                .map(join -> UserSimpleResponse.from(join.getMembership().getCreater()))
+                .toList();
     }
 }

--- a/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
+++ b/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
@@ -1,7 +1,9 @@
 package com.swef.cookcode.membership.service;
 
 import com.swef.cookcode.membership.domain.Membership;
+import com.swef.cookcode.membership.domain.MembershipJoin;
 import com.swef.cookcode.membership.dto.MembershipCreateRequest;
+import com.swef.cookcode.membership.repository.MembershipJoinRepository;
 import com.swef.cookcode.membership.repository.MembershipRepository;
 import com.swef.cookcode.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,8 @@ public class MembershipService {
 
     private final MembershipRepository membershipRepository;
 
+    private final MembershipJoinRepository membershipJoinRepository;
+
     @Transactional
     public void createMembership(User user, MembershipCreateRequest request) {
         Membership membership = Membership.createEntity(user, request);
@@ -23,7 +27,17 @@ public class MembershipService {
         membershipRepository.save(membership);
     }
 
+    @Transactional(readOnly = true)
     public List<Membership> getMembership(User user) {
         return membershipRepository.findByCreater(user);
+    }
+
+    @Transactional
+    public void joinMembership(User user, Long membershipId) {
+        Membership membership = membershipRepository.getReferenceById(membershipId);
+
+        MembershipJoin membershipJoin = MembershipJoin.createEntity(membership, user);
+
+        membershipJoinRepository.save(membershipJoin);
     }
 }

--- a/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
+++ b/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
@@ -2,6 +2,7 @@ package com.swef.cookcode.membership.service;
 
 import com.swef.cookcode.membership.domain.Membership;
 import com.swef.cookcode.membership.domain.MembershipJoin;
+import com.swef.cookcode.membership.dto.JoiningMembershipResponse;
 import com.swef.cookcode.membership.dto.MembershipCreateRequest;
 import com.swef.cookcode.membership.dto.MembershipResponse;
 import com.swef.cookcode.membership.repository.MembershipJoinRepository;
@@ -50,11 +51,11 @@ public class MembershipService {
     }
 
     @Transactional
-    public List<UserSimpleResponse> getJoiningMemberships(User user) {
+    public List<JoiningMembershipResponse> getJoiningMemberships(User user) {
         List<MembershipJoin> joiningMemberships = membershipJoinRepository.findBySubscriber(user);
 
         return joiningMemberships.stream()
-                .map(join -> UserSimpleResponse.from(join.getMembership().getCreater()))
+                .map(join -> JoiningMembershipResponse.from(join.getMembership()))
                 .toList();
     }
 }

--- a/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
+++ b/src/main/java/com/swef/cookcode/membership/service/MembershipService.java
@@ -3,9 +3,11 @@ package com.swef.cookcode.membership.service;
 import com.swef.cookcode.membership.domain.Membership;
 import com.swef.cookcode.membership.domain.MembershipJoin;
 import com.swef.cookcode.membership.dto.MembershipCreateRequest;
+import com.swef.cookcode.membership.dto.MembershipResponse;
 import com.swef.cookcode.membership.repository.MembershipJoinRepository;
 import com.swef.cookcode.membership.repository.MembershipRepository;
 import com.swef.cookcode.user.domain.User;
+import com.swef.cookcode.user.service.UserSimpleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MembershipService {
+
+    private final UserSimpleService userSimpleService;
 
     private final MembershipRepository membershipRepository;
 
@@ -28,8 +32,11 @@ public class MembershipService {
     }
 
     @Transactional(readOnly = true)
-    public List<Membership> getMembership(User user) {
-        return membershipRepository.findByCreater(user);
+    public List<MembershipResponse> getMembership(Long createrId) {
+        User creater = userSimpleService.getUserById(createrId);
+
+        List<Membership> membershipList = membershipRepository.findByCreater(creater);
+        return membershipList.stream().map(MembershipResponse::from).toList();
     }
 
     @Transactional


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치\
feat/membership -> main

## 변경 사항
멤버십 엔티티 생성
크리에이터 멤버십 등급 생성
크리에이터의 멤버십 등급 조회
유저가 크리에이터의 멤버십 등급에 가입
유저가 크리에이터의 멤버십 등급에 탈퇴
유저가 가입한 멤버십 목록 조회

## 집중했으면 좋은 점
n+1 방지를 위해 가입한 멤버십 조회 시 모든 필요 테이블을 fetch join 하였습니다.