### PR TITLE
레시피 구독, 멤버십 조회 구현

### DIFF
--- a/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/swef/cookcode/common/config/WebSecurityConfig.java
@@ -93,6 +93,7 @@ public class WebSecurityConfig {
                     requests
                     .requestMatchers(HttpMethod.GET, "/api/v1/account/password").permitAll()
                     .requestMatchers("/api/v1/account/signin", "/api/v1/account/signup", "/api/v1/account/check", "/health", "/api/v1/account/email").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/membership").hasRole("INFLUENCER")
                     .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                     .anyRequest().access(auth);
                 }).cors(it -> {})

--- a/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
+++ b/src/main/java/com/swef/cookcode/recipe/controller/RecipeController.java
@@ -160,6 +160,38 @@ public class RecipeController {
         return ResponseEntity.ok(apiResponse);
     }
 
+    @GetMapping("/publisher")
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipeOfPublishers(@CurrentUser User user,
+                                                                                            @RequestParam(value = "cookable", required = false) Boolean isCookable,
+                                                                                            @RequestParam(value = "month", required = false) Integer month,
+                                                                                            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                                            Pageable pageable)
+    {
+        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.getRecipeOfPublishers(user, isCookable, month, pageable));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("구독한 크리에이터의 레시피 다건 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @GetMapping("/membership")
+    public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipeOfMemberships(@CurrentUser User user,
+                                                                                            @RequestParam(value = "cookable", required = false) Boolean isCookable,
+                                                                                            @RequestParam(value = "month", required = false) Integer month,
+                                                                                            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                                                    Pageable pageable)
+    {
+        SliceResponse<RecipeResponse> response = new SliceResponse<>(recipeService.getRecipeOfMemberships(user, isCookable, month, pageable));
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("멤버십 크리에이터의 레시피 다건 조회 성공")
+                .status(HttpStatus.OK.value())
+                .data(response)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
     @GetMapping("/user/{targetUserId}")
     public ResponseEntity<ApiResponse<SliceResponse<RecipeResponse>>> getRecipesOfUser(@CurrentUser User user, @PathVariable(value = "targetUserId") Long userId,
                                                                                        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeCustomRepository.java
@@ -10,9 +10,14 @@ import org.springframework.data.domain.Slice;
 public interface RecipeCustomRepository {
     Slice<RecipeResponse> findRecipes(Long userId, Boolean isCookable, Integer month, Pageable pageable);
 
+    Slice<RecipeResponse> findRecipesOfPublishers(Long id, Boolean isCookable, Integer month, Pageable pageable);
+
     Slice<RecipeResponse> searchRecipes(Long userId, String query, Boolean isCookable, Pageable pageable);
+
+    Slice<RecipeResponse> findRecipesOfMemberships(Long userId, Boolean isCookable, Integer month, Pageable pageable);
 
     Slice<RecipeResponse> findRecipesOfUser(Long userId, Long targetUserId, Pageable pageable);
 
     Optional<RecipeDetailResponse> findRecipeById(Long userId, Long recipeId);
+
 }

--- a/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
+++ b/src/main/java/com/swef/cookcode/recipe/repository/RecipeRepositoryImpl.java
@@ -5,10 +5,14 @@ import static com.swef.cookcode.common.util.Util.hasNextInSlice;
 import static com.swef.cookcode.fridge.domain.QFridge.fridge;
 import static com.swef.cookcode.fridge.domain.QFridgeIngredient.fridgeIngredient;
 import static com.swef.cookcode.fridge.domain.QIngredient.ingredient;
+import static com.swef.cookcode.membership.domain.QMembership.membership;
+import static com.swef.cookcode.membership.domain.QMembershipJoin.membershipJoin;
 import static com.swef.cookcode.recipe.domain.QRecipe.recipe;
 import static com.swef.cookcode.recipe.domain.QRecipeComment.recipeComment;
 import static com.swef.cookcode.recipe.domain.QRecipeIngred.recipeIngred;
 import static com.swef.cookcode.recipe.domain.QRecipeLike.recipeLike;
+import static com.swef.cookcode.user.domain.QSubscribe.subscribe;
+import static com.swef.cookcode.user.domain.QUser.user;
 import static java.util.Objects.nonNull;
 
 import com.querydsl.core.types.Projections;
@@ -23,6 +27,8 @@ import com.swef.cookcode.recipe.dto.response.RecipeDetailResponse;
 import com.swef.cookcode.recipe.dto.response.RecipeResponse;
 import java.util.List;
 import java.util.Optional;
+
+import com.swef.cookcode.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -39,8 +45,10 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
     public Slice<RecipeResponse> findRecipes(Long userId, Boolean isCookable, Integer month, Pageable pageable) {
         JPAQuery<RecipeResponse> query = selectRecipesWithCookableAndLike(userId)
                 .groupBy(recipe.id);
+
         filterIfCookable(isCookable, query);
         filterIfMonth(month, query);
+
         List<RecipeResponse> result = query.orderBy(
                 QueryUtil.getOrderSpecifiers(
                         pageable.getSort(), List.of(recipeLike.countDistinct(), recipeComment.countDistinct()), recipe.createdAt
@@ -49,6 +57,65 @@ public class RecipeRepositoryImpl implements RecipeCustomRepository{
                 .limit(pageable.getPageSize()+1).fetch();
         return new SliceImpl<>(result, pageable, hasNextInSlice(result, pageable));
     }
+
+    @Override
+    public Slice<RecipeResponse> findRecipesOfPublishers(Long userId, Boolean isCookable, Integer month, Pageable pageable) {
+        JPAQuery<RecipeResponse> query = selectRecipesWithCookableAndLike(userId)
+                .where(recipe.author.id.in(selectPublishers(userId)))
+                .groupBy(recipe.id);
+
+        filterIfCookable(isCookable, query);
+        filterIfMonth(month, query);
+
+        List<RecipeResponse> result = query.orderBy(
+                        QueryUtil.getOrderSpecifiers(
+                                pageable.getSort(), List.of(recipeLike.countDistinct(), recipeComment.countDistinct()), recipe.createdAt
+                        ))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize()+1).fetch();
+
+        return new SliceImpl<>(result, pageable, hasNextInSlice(result, pageable));
+    }
+
+    private List<Long> selectPublishers(Long userId){
+        return queryFactory.select(
+                        user.id
+                )
+                .from(user)
+                .innerJoin(subscribe).on(subscribe.subscriber.id.eq(userId))
+                .fetch();
+    }
+
+
+    @Override
+    public Slice<RecipeResponse> findRecipesOfMemberships(Long userId, Boolean isCookable, Integer month, Pageable pageable) {
+        JPAQuery<RecipeResponse> query = selectRecipesWithCookableAndLike(userId)
+                .where(recipe.author.id.in(selectMemberships(userId)))
+                .groupBy(recipe.id);
+
+        filterIfCookable(isCookable, query);
+        filterIfMonth(month, query);
+
+        List<RecipeResponse> result = query.orderBy(
+                        QueryUtil.getOrderSpecifiers(
+                                pageable.getSort(), List.of(recipeLike.countDistinct(), recipeComment.countDistinct()), recipe.createdAt
+                        ))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize()+1).fetch();
+
+        return new SliceImpl<>(result, pageable, hasNextInSlice(result, pageable));
+    }
+
+    private List<Long> selectMemberships(Long userId) {
+        return queryFactory.select(membership.creater.id)
+                .from(membership)
+                .leftJoin(membershipJoin)
+                .on(membership.id.eq(membershipJoin.membership.id))
+                .where(membershipJoin.subscriber.id.eq(userId))
+                .groupBy(membership.creater)
+                .fetch();
+    }
+
 
     @Override
     public Slice<RecipeResponse> findRecipesOfUser(Long userId, Long targetUserId, Pageable pageable) {

--- a/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
+++ b/src/main/java/com/swef/cookcode/recipe/service/RecipeService.java
@@ -175,6 +175,20 @@ public class RecipeService {
     }
 
     @Transactional(readOnly = true)
+    public Slice<RecipeResponse> getRecipeOfPublishers(User user, Boolean isCookable, Integer month, Pageable pageable) {
+        if (nonNull(month) && (month < 1 || month > 12)) throw new InvalidRequestException(ErrorCode.INVALID_INPUT_VALUE);
+        Slice<RecipeResponse> responses = recipeRepository.findRecipesOfPublishers(user.getId(), isCookable, month, pageable);
+        return responses;
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<RecipeResponse> getRecipeOfMemberships(User user, Boolean isCookable, Integer month, Pageable pageable) {
+        if (nonNull(month) && (month < 1 || month > 12)) throw new InvalidRequestException(ErrorCode.INVALID_INPUT_VALUE);
+        Slice<RecipeResponse> responses = recipeRepository.findRecipesOfMemberships(user.getId(), isCookable, month, pageable);
+        return responses;
+    }
+
+    @Transactional(readOnly = true)
     public Slice<RecipeResponse> getRecipeResponsesOfUser(User user, Long targetUserId, Pageable pageable) {
         userSimpleService.checkUserExists(targetUserId);
         Slice<RecipeResponse> responses = recipeRepository.findRecipesOfUser(user.getId(), targetUserId, pageable);
@@ -224,6 +238,5 @@ public class RecipeService {
     void unlikeRecipe(RecipeLike recipeLike) {
         recipeLikeRepository.delete(recipeLike);
     }
-
 
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/recipe-subscribe-membership -> main

## 변경 사항
구독, 멤버십의 레시피 조회 구현
멤버십 등록 권한 체크


## 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
