### PR TITLE
댓글 도메인 부모 클래스 추출

### DIFF
--- a/src/main/java/com/swef/cookcode/common/dto/CommentResponse.java
+++ b/src/main/java/com/swef/cookcode/common/dto/CommentResponse.java
@@ -1,7 +1,6 @@
 package com.swef.cookcode.common.dto;
 
-import com.swef.cookcode.cookie.domain.CookieComment;
-import com.swef.cookcode.recipe.domain.RecipeComment;
+import com.swef.cookcode.common.entity.Comment;
 import com.swef.cookcode.user.dto.response.UserSimpleResponse;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -15,15 +14,7 @@ public class CommentResponse {
 
     private final String comment;
 
-    public static CommentResponse from(RecipeComment comment) {
-        return CommentResponse.builder()
-                .commentId(comment.getId())
-                .user(UserSimpleResponse.from(comment.getUser()))
-                .comment(comment.getComment())
-                .build();
-    }
-
-    public static CommentResponse from(CookieComment comment) {
+    public static CommentResponse from(Comment comment) {
         return CommentResponse.builder()
                 .commentId(comment.getId())
                 .user(UserSimpleResponse.from(comment.getUser()))

--- a/src/main/java/com/swef/cookcode/common/entity/Comment.java
+++ b/src/main/java/com/swef/cookcode/common/entity/Comment.java
@@ -1,0 +1,39 @@
+package com.swef.cookcode.common.entity;
+
+import com.swef.cookcode.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Comment extends BaseEntity{
+
+    private static final int MAX_COMMENT_LENGTH = 500;
+
+    @Id
+    @Column(name = "comment_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false, length = MAX_COMMENT_LENGTH)
+    private String comment;
+
+    public Comment(User user, String comment) {
+        this.user = user;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/swef/cookcode/cookie/domain/CookieComment.java
+++ b/src/main/java/com/swef/cookcode/cookie/domain/CookieComment.java
@@ -1,8 +1,12 @@
 package com.swef.cookcode.cookie.domain;
 
-import com.swef.cookcode.common.entity.BaseEntity;
+import com.swef.cookcode.common.entity.Comment;
 import com.swef.cookcode.user.domain.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,30 +15,15 @@ import lombok.NoArgsConstructor;
 @Table(name = "cookie_comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class CookieComment extends BaseEntity {
-
-    private static final int MAX_COMMENT_LENGTH = 300;
-
-    @Id
-    @Column(name = "cookie_comment_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+public class CookieComment extends Comment {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cookie_id")
     private Cookie cookie;
 
-    @Column(name = "comment", nullable = false, length = MAX_COMMENT_LENGTH)
-    private String comment;
-
     public CookieComment(User user, Cookie cookie, String comment) {
-        this.user = user;
+        super(user, comment);
         this.cookie = cookie;
-        this.comment = comment;
     }
 
     public static CookieComment createEntity(User user, Cookie cookie, String comment) {

--- a/src/main/java/com/swef/cookcode/cookie/domain/CookieComment.java
+++ b/src/main/java/com/swef/cookcode/cookie/domain/CookieComment.java
@@ -2,6 +2,8 @@ package com.swef.cookcode.cookie.domain;
 
 import com.swef.cookcode.common.entity.Comment;
 import com.swef.cookcode.user.domain.User;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -13,6 +15,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cookie_comment")
+@AttributeOverride(
+        name = "id",
+        column = @Column(name = "cookie_comment_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CookieComment extends Comment {

--- a/src/main/java/com/swef/cookcode/recipe/domain/RecipeComment.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/RecipeComment.java
@@ -2,6 +2,8 @@ package com.swef.cookcode.recipe.domain;
 
 import com.swef.cookcode.common.entity.Comment;
 import com.swef.cookcode.user.domain.User;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -13,6 +15,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "recipe_comment")
+@AttributeOverride(
+        name = "id",
+        column = @Column(name = "recipe_comment_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class RecipeComment extends Comment {

--- a/src/main/java/com/swef/cookcode/recipe/domain/RecipeComment.java
+++ b/src/main/java/com/swef/cookcode/recipe/domain/RecipeComment.java
@@ -1,20 +1,13 @@
 package com.swef.cookcode.recipe.domain;
 
-import com.swef.cookcode.common.entity.BaseEntity;
+import com.swef.cookcode.common.entity.Comment;
 import com.swef.cookcode.user.domain.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,30 +15,17 @@ import lombok.NoArgsConstructor;
 @Table(name = "recipe_comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class RecipeComment extends BaseEntity {
+public class RecipeComment extends Comment {
 
     private static final int MAX_COMMENT_LENGTH = 500;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "recipe_comment_id")
-    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
-
-    @Column(nullable = false, length = MAX_COMMENT_LENGTH)
-    private String comment;
-
     public RecipeComment(Recipe recipe, User user, String comment) {
+        super(user, comment);
         this.recipe = recipe;
-        this.user = user;
-        this.comment = comment;
     }
 
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리팩토링

## 반영 브랜치
refactor/oop-comment -> main

## 변경 사항
* CookieComment, RecipeComment 클래스에서 동일한 필드에 대해서 Comment 클래스로 추출하였습니다.
* CommentResponse에서 생성 메소드 from 오버로딩을 삭제하고, Comment 클래스를 매개변수로 받게 하여 다형성을 높였습니다.
* CookieComment, RecipeComment에서 사용하는 id의 column 명은 @AttributeOverride를 통해 재정의하였습니다.

## 집중했으면 좋은 점
* Comment 부모 클래스로 추출
